### PR TITLE
[#12] 회원정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/config/WebMvcConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/WebMvcConfig.java
@@ -1,0 +1,30 @@
+package com.show.showticketingservice.config;
+
+import com.show.showticketingservice.tool.interceptor.LoginCheckInterceptor;
+import com.show.showticketingservice.tool.resolver.CurrentUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoginCheckInterceptor loginCheckInterceptor;
+
+    private final CurrentUserArgumentResolver currentUserArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginCheckInterceptor);
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(currentUserArgumentResolver);
+    }
+}

--- a/src/main/java/com/show/showticketingservice/controller/MyPageController.java
+++ b/src/main/java/com/show/showticketingservice/controller/MyPageController.java
@@ -1,0 +1,29 @@
+package com.show.showticketingservice.controller;
+
+import com.show.showticketingservice.model.user.UserSession;
+import com.show.showticketingservice.model.user.UserUpdateRequest;
+import com.show.showticketingservice.service.UserService;
+import com.show.showticketingservice.tool.annotation.CurrentUser;
+import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my-infos")
+public class MyPageController {
+
+    private final UserService userService;
+
+    @PutMapping
+    @UserAuthenticationNecessary
+    public void updateUserInfo(@CurrentUser UserSession userSession, @RequestBody @Valid UserUpdateRequest userUpdateRequest) {
+        userService.updateUserInfo(userSession, userUpdateRequest);
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/controller/UserController.java
+++ b/src/main/java/com/show/showticketingservice/controller/UserController.java
@@ -4,6 +4,7 @@ import com.show.showticketingservice.model.user.UserLoginRequest;
 import com.show.showticketingservice.model.user.UserRequest;
 import com.show.showticketingservice.service.LoginService;
 import com.show.showticketingservice.service.UserService;
+import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +25,7 @@ public class UserController {
     }
 
     @GetMapping("/logout")
+    @UserAuthenticationNecessary
     public void logout() {
         loginService.logout();
     }

--- a/src/main/java/com/show/showticketingservice/mapper/UserMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.mapper;
 
+import com.show.showticketingservice.model.user.UserUpdateRequest;
 import com.show.showticketingservice.model.user.UserRequest;
 import com.show.showticketingservice.model.user.UserResponse;
 import org.apache.ibatis.annotations.*;
@@ -12,5 +13,7 @@ public interface UserMapper {
     boolean isIdExists(String userId);
 
     UserResponse getUserByUserId(String userId);
+
+    void updateUserInfo(@Param("userId") String userId, @Param("updateRequest") UserUpdateRequest userUpdateRequest);
 }
 

--- a/src/main/java/com/show/showticketingservice/model/user/UserSession.java
+++ b/src/main/java/com/show/showticketingservice/model/user/UserSession.java
@@ -1,0 +1,15 @@
+package com.show.showticketingservice.model.user;
+
+import com.show.showticketingservice.model.enumerations.UserType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserSession {
+
+    private final String userId;
+
+    private final UserType userType;
+
+}

--- a/src/main/java/com/show/showticketingservice/model/user/UserUpdateRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/user/UserUpdateRequest.java
@@ -1,0 +1,35 @@
+package com.show.showticketingservice.model.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserUpdateRequest {
+
+    @NotBlank(message = "새 비밀번호를 입력하세요.")
+    @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[`~!@#$%^&*+=(),._?\":{}|<>/-])(?=\\S+$).{6,20}$", message = "비밀번호는 숫자,특수문자,영문 대/소문자가 모두 포함된 6~20자리로 입력하세요.")
+    private final String newPassword;
+
+    @NotBlank(message = "전화번호를 입력하세요.")
+    @Pattern(regexp="^010-(\\d{4})-(\\d{4})$", message = "전화번호는 '-'를 포함하여 13자리로 입력하세요.")
+    private final String newPhoneNum;
+
+    @NotBlank(message = "주소를 입력하세요.")
+    @Length(max = 100, message = "주소 입력은 최대 100자까지 가능합니다.")
+    private final String newAddress;
+
+    public UserUpdateRequest pwEncryptedUserUpdateRequest(String encryptedPw) {
+        return builder()
+                .newPassword(encryptedPw)
+                .newPhoneNum(getNewPhoneNum())
+                .newAddress(getNewAddress())
+                .build();
+    }
+}

--- a/src/main/java/com/show/showticketingservice/service/LoginService.java
+++ b/src/main/java/com/show/showticketingservice/service/LoginService.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.model.user.UserLoginRequest;
+import com.show.showticketingservice.model.user.UserSession;
 
 public interface LoginService {
 
@@ -8,4 +9,7 @@ public interface LoginService {
 
     void logout();
 
+    boolean isUserLoggedIn();
+
+    UserSession getCurrentUserSession();
 }

--- a/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
+++ b/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
@@ -1,15 +1,15 @@
 package com.show.showticketingservice.service;
 
-import com.show.showticketingservice.exception.authentication.UserNotLoggedInException;
 import com.show.showticketingservice.model.user.UserLoginRequest;
 import com.show.showticketingservice.model.user.UserResponse;
+import com.show.showticketingservice.model.user.UserSession;
 import com.sun.jdi.request.DuplicateRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import javax.servlet.http.HttpSession;
 
-import static com.show.showticketingservice.tool.constants.UserConstant.USER_ID;
+import static com.show.showticketingservice.tool.constants.UserConstant.USER;
 
 @Service
 @RequiredArgsConstructor
@@ -22,23 +22,30 @@ public class SessionLoginService implements LoginService {
     @Override
     public void login(UserLoginRequest userLoginRequest) {
 
-        if (httpSession.getAttribute(USER_ID) != null) {
+        if (httpSession.getAttribute(USER) != null) {
             throw new DuplicateRequestException("이미 로그인 된 상태입니다.");
         }
 
         UserResponse userResponse = userService.getUser(userLoginRequest.getUserId(), userLoginRequest.getPassword());
 
-        httpSession.setAttribute(USER_ID, userResponse.getUserId());
+        UserSession userSession = new UserSession(userResponse.getUserId(), userResponse.getUserType());
+
+        httpSession.setAttribute(USER, userSession);
     }
 
     @Override
     public void logout() {
-
-        if(httpSession.getAttribute(USER_ID) == null) {
-            throw new UserNotLoggedInException();
-        }
-
         httpSession.invalidate();
+    }
+
+    @Override
+    public boolean isUserLoggedIn() {
+        return httpSession.getAttribute(USER) != null;
+    }
+
+    @Override
+    public UserSession getCurrentUserSession() {
+        return (UserSession) httpSession.getAttribute(USER);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/service/UserService.java
+++ b/src/main/java/com/show/showticketingservice/service/UserService.java
@@ -4,8 +4,10 @@ import com.show.showticketingservice.exception.authentication.UserIdAlreadyExist
 import com.show.showticketingservice.exception.authentication.UserIdNotExistsException;
 import com.show.showticketingservice.exception.authentication.UserPasswordWrongException;
 import com.show.showticketingservice.mapper.UserMapper;
+import com.show.showticketingservice.model.user.UserUpdateRequest;
 import com.show.showticketingservice.model.user.UserRequest;
 import com.show.showticketingservice.model.user.UserResponse;
+import com.show.showticketingservice.model.user.UserSession;
 import com.show.showticketingservice.tool.encryptor.PasswordEncryptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -50,5 +52,10 @@ public class UserService {
 
     private boolean isPasswordMatches(String passwordRequest, String userPassword) {
         return passwordEncryptor.isMatched(passwordRequest, userPassword);
+    }
+
+    public void updateUserInfo(UserSession userSession, UserUpdateRequest userUpdateRequest) {
+        String newEncryptedPassword = passwordEncryptor.encrypt(userUpdateRequest.getNewPassword());
+        userMapper.updateUserInfo(userSession.getUserId(), userUpdateRequest.pwEncryptedUserUpdateRequest(newEncryptedPassword));
     }
 }

--- a/src/main/java/com/show/showticketingservice/tool/annotation/CurrentUser.java
+++ b/src/main/java/com/show/showticketingservice/tool/annotation/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.show.showticketingservice.tool.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {
+}

--- a/src/main/java/com/show/showticketingservice/tool/annotation/UserAuthenticationNecessary.java
+++ b/src/main/java/com/show/showticketingservice/tool/annotation/UserAuthenticationNecessary.java
@@ -1,0 +1,11 @@
+package com.show.showticketingservice.tool.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserAuthenticationNecessary {
+}

--- a/src/main/java/com/show/showticketingservice/tool/constants/UserConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/UserConstant.java
@@ -2,6 +2,6 @@ package com.show.showticketingservice.tool.constants;
 
 public class UserConstant {
 
-    public static final String USER_ID = "userId";
+    public static final String USER = "user";
 
 }

--- a/src/main/java/com/show/showticketingservice/tool/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/show/showticketingservice/tool/interceptor/LoginCheckInterceptor.java
@@ -3,7 +3,6 @@ package com.show.showticketingservice.tool.interceptor;
 import com.show.showticketingservice.exception.authentication.UserNotLoggedInException;
 import com.show.showticketingservice.service.LoginService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
@@ -13,7 +12,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @Component
-@Getter
 @RequiredArgsConstructor
 public class LoginCheckInterceptor implements HandlerInterceptor {
 
@@ -23,6 +21,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         HandlerMethod handlerMethod = (HandlerMethod) handler;
         UserAuthenticationNecessary userAuthentication = handlerMethod.getMethodAnnotation(UserAuthenticationNecessary.class);
+
         if (userAuthentication != null && !loginService.isUserLoggedIn()) {
             throw new UserNotLoggedInException();
         }

--- a/src/main/java/com/show/showticketingservice/tool/interceptor/LoginCheckInterceptor.java
+++ b/src/main/java/com/show/showticketingservice/tool/interceptor/LoginCheckInterceptor.java
@@ -1,0 +1,32 @@
+package com.show.showticketingservice.tool.interceptor;
+
+import com.show.showticketingservice.exception.authentication.UserNotLoggedInException;
+import com.show.showticketingservice.service.LoginService;
+import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+@Getter
+@RequiredArgsConstructor
+public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    private final LoginService loginService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        UserAuthenticationNecessary userAuthentication = handlerMethod.getMethodAnnotation(UserAuthenticationNecessary.class);
+        if (userAuthentication != null && !loginService.isUserLoggedIn()) {
+            throw new UserNotLoggedInException();
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/show/showticketingservice/tool/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/show/showticketingservice/tool/resolver/CurrentUserArgumentResolver.java
@@ -1,7 +1,7 @@
 package com.show.showticketingservice.tool.resolver;
 
-import com.show.showticketingservice.model.user.UserSession;
 import com.show.showticketingservice.service.LoginService;
+import com.show.showticketingservice.tool.annotation.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
@@ -18,7 +18,7 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
 
     @Override
     public boolean supportsParameter(MethodParameter methodParameter) {
-        return methodParameter.getParameterType().equals(UserSession.class);
+        return methodParameter.hasParameterAnnotation(CurrentUser.class);
     }
 
     @Override

--- a/src/main/java/com/show/showticketingservice/tool/resolver/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/show/showticketingservice/tool/resolver/CurrentUserArgumentResolver.java
@@ -1,0 +1,28 @@
+package com.show.showticketingservice.tool.resolver;
+
+import com.show.showticketingservice.model.user.UserSession;
+import com.show.showticketingservice.service.LoginService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final LoginService loginService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter methodParameter) {
+        return methodParameter.getParameterType().equals(UserSession.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter methodParameter, ModelAndViewContainer modelAndViewContainer, NativeWebRequest nativeWebRequest, WebDataBinderFactory webDataBinderFactory) throws Exception {
+        return loginService.getCurrentUserSession();
+    }
+}

--- a/src/main/resources/mybatis/mappers/UserMapper.xml
+++ b/src/main/resources/mybatis/mappers/UserMapper.xml
@@ -18,5 +18,11 @@
         FROM user
         WHERE userId = #{userId}
     </select>
+    
+    <update id="updateUserInfo" parameterType="map" >
+        UPDATE user
+        SET password = #{updateRequest.newPassword}, phoneNum = #{updateRequest.newPhoneNum}, address = #{updateRequest.newAddress}
+        WHERE userId = #{userId}
+    </update>
 
 </mapper>

--- a/src/test/java/com/show/showticketingservice/controller/MyPageControllerTest.java
+++ b/src/test/java/com/show/showticketingservice/controller/MyPageControllerTest.java
@@ -1,0 +1,153 @@
+package com.show.showticketingservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.show.showticketingservice.model.enumerations.UserType;
+import com.show.showticketingservice.model.user.UserLoginRequest;
+import com.show.showticketingservice.model.user.UserRequest;
+import com.show.showticketingservice.model.user.UserUpdateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class MyPageControllerTest {
+
+    private UserRequest testUser;
+
+    private UserUpdateRequest updateRequest;
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    MockHttpSession httpSession;
+
+    @BeforeEach
+    public void init() {
+        testUser = new UserRequest("testId1", "testPW1234#", "Test User", "010-1111-1111", "user1@example.com", "Seoul, South Korea", UserType.GENERAL);
+
+        updateRequest = new UserUpdateRequest("!validPW123", "010-1234-5678", "Busan, South Korea");
+    }
+
+    private void insertUser(UserRequest userRequest) throws Exception {
+        String content = objectMapper.writeValueAsString(userRequest);
+
+        mvc.perform(post("/users")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isCreated());
+    }
+
+    private void loginUser(UserRequest userRequest) throws Exception {
+        UserLoginRequest userLoginRequest = new UserLoginRequest(userRequest.getUserId(), userRequest.getPassword());
+
+        String content = objectMapper.writeValueAsString(userLoginRequest);
+
+        mvc.perform(post("/login")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .session(httpSession))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원정보 수정 성공 시 Http Status 200 (OK) 리턴")
+    public void updateUserInfo() throws Exception {
+        insertUser(testUser);
+        loginUser(testUser);
+
+        String content = objectMapper.writeValueAsString(updateRequest);
+
+        mvc.perform(put("/my-infos")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .session(httpSession))
+                .andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("로그인 하지 않은 상태로 회원정보 수정 시도 시 Http Status 401 (Unauthorized) 리턴")
+    public void updateUserInfoWithoutLogin() throws Exception {
+        insertUser(testUser);
+
+        String content = objectMapper.writeValueAsString(updateRequest);
+
+        mvc.perform(put("/my-infos")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .session(httpSession))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("invalid 한 값(PW)으로 회원정보 수정 시도 시 Http Status 400 (Bad Request) 리턴")
+    public void updateUserWithInvalidPw() throws Exception {
+        insertUser(testUser);
+        loginUser(testUser);
+
+        UserUpdateRequest invalidRequest = UserUpdateRequest.builder()
+                .newPassword("invalidPw")
+                .newPhoneNum(updateRequest.getNewPhoneNum())
+                .newAddress(updateRequest.getNewAddress())
+                .build();
+
+        String content = objectMapper.writeValueAsString(invalidRequest);
+
+        mvc.perform(put("/my-infos")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .session(httpSession))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("invalid 한 값(phoneNum)으로 회원정보 수정 시도 시 Http Status 400 (Bad Request) 리턴")
+    public void updateUserWithInvalidPhoneNum() throws Exception {
+        insertUser(testUser);
+        loginUser(testUser);
+
+        UserUpdateRequest invalidRequest = UserUpdateRequest.builder()
+                .newPassword(updateRequest.getNewPassword())
+                .newPhoneNum("010123-456")
+                .newAddress(updateRequest.getNewAddress())
+                .build();
+
+        String content = objectMapper.writeValueAsString(invalidRequest);
+
+        mvc.perform(put("/my-infos")
+                .content(content)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .session(httpSession))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+}

--- a/src/test/java/com/show/showticketingservice/controller/UserControllerTest.java
+++ b/src/test/java/com/show/showticketingservice/controller/UserControllerTest.java
@@ -185,4 +185,6 @@ class UserControllerTest {
                 .andExpect(status().isUnauthorized());
     }
 
+
+
 }


### PR DESCRIPTION
- 수정 가능 정보: 비밀번호, 전화번호, 주소
- 현재 세션의 User를 가져와 정보 수정 기능 구현
- 세션에 저장되는 데이터를 userId에서 UserSession 객체(필드: userId, userType)로 변경
- `LoginCheckInterceptor`: Interceptor로 특정 url에 접근 전 로그인이 되어있는지 확인 (annotation: `@UserAuthenticationNecessary`)
- `CurrentUserArgumentResolver`: 컨트롤러 메소드 파라미터 중 세션데이터(UserSession) 타입 확인 및 가져오기 (annotation: `@CurrentUser`)
- 테스트 코드 작성