### PR TITLE
[#19] 회원 타입별 로그인 구분

### DIFF
--- a/src/main/java/com/show/showticketingservice/controller/UserController.java
+++ b/src/main/java/com/show/showticketingservice/controller/UserController.java
@@ -1,12 +1,16 @@
 package com.show.showticketingservice.controller;
 
+import com.show.showticketingservice.model.enumerations.UserType;
+import com.show.showticketingservice.model.responses.Authority;
 import com.show.showticketingservice.model.user.UserLoginRequest;
 import com.show.showticketingservice.model.user.UserRequest;
 import com.show.showticketingservice.service.LoginService;
 import com.show.showticketingservice.service.UserService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
+import com.show.showticketingservice.tool.response.UserAuthorityResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -20,8 +24,15 @@ public class UserController {
     private final LoginService loginService;
 
     @PostMapping("/login")
-    public void login(@RequestBody UserLoginRequest userLoginRequest) {
-        loginService.login(userLoginRequest);
+    public ResponseEntity<Authority> login(@RequestBody UserLoginRequest userLoginRequest) {
+        UserType userType = loginService.login(userLoginRequest);
+
+        if (userType == UserType.GENERAL) {
+            return UserAuthorityResponse.OK_GENERAL;
+        } else {
+            return UserAuthorityResponse.OK_MANAGER;
+        }
+
     }
 
     @GetMapping("/logout")

--- a/src/main/java/com/show/showticketingservice/model/responses/Authority.java
+++ b/src/main/java/com/show/showticketingservice/model/responses/Authority.java
@@ -1,0 +1,13 @@
+package com.show.showticketingservice.model.responses;
+
+import com.show.showticketingservice.model.enumerations.UserType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Authority {
+
+    private final UserType userType;
+
+}

--- a/src/main/java/com/show/showticketingservice/model/responses/ExceptionResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/responses/ExceptionResponse.java
@@ -1,4 +1,4 @@
-package com.show.showticketingservice.model.exception;
+package com.show.showticketingservice.model.responses;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/show/showticketingservice/service/LoginService.java
+++ b/src/main/java/com/show/showticketingservice/service/LoginService.java
@@ -1,11 +1,12 @@
 package com.show.showticketingservice.service;
 
+import com.show.showticketingservice.model.enumerations.UserType;
 import com.show.showticketingservice.model.user.UserLoginRequest;
 import com.show.showticketingservice.model.user.UserSession;
 
 public interface LoginService {
 
-    void login(UserLoginRequest userLoginRequest);
+    UserType login(UserLoginRequest userLoginRequest);
 
     void logout();
 

--- a/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
+++ b/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.service;
 
+import com.show.showticketingservice.model.enumerations.UserType;
 import com.show.showticketingservice.model.user.UserLoginRequest;
 import com.show.showticketingservice.model.user.UserResponse;
 import com.show.showticketingservice.model.user.UserSession;
@@ -20,7 +21,7 @@ public class SessionLoginService implements LoginService {
     private final UserService userService;
 
     @Override
-    public void login(UserLoginRequest userLoginRequest) {
+    public UserType login(UserLoginRequest userLoginRequest) {
 
         if (httpSession.getAttribute(USER) != null) {
             throw new DuplicateRequestException("이미 로그인 된 상태입니다.");
@@ -31,6 +32,8 @@ public class SessionLoginService implements LoginService {
         UserSession userSession = new UserSession(userResponse.getUserId(), userResponse.getUserType());
 
         httpSession.setAttribute(USER, userSession);
+
+        return userResponse.getUserType();
     }
 
     @Override

--- a/src/main/java/com/show/showticketingservice/tool/advice/AuthenticationExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/AuthenticationExceptionAdvice.java
@@ -4,7 +4,7 @@ import com.show.showticketingservice.exception.authentication.UserIdAlreadyExist
 import com.show.showticketingservice.exception.authentication.UserIdNotExistsException;
 import com.show.showticketingservice.exception.authentication.UserNotLoggedInException;
 import com.show.showticketingservice.exception.authentication.UserPasswordWrongException;
-import com.show.showticketingservice.model.exception.ExceptionResponse;
+import com.show.showticketingservice.model.responses.ExceptionResponse;
 import com.sun.jdi.request.DuplicateRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/show/showticketingservice/tool/response/HttpStatusResponse.java
+++ b/src/main/java/com/show/showticketingservice/tool/response/HttpStatusResponse.java
@@ -1,4 +1,4 @@
-package com.show.showticketingservice.tool;
+package com.show.showticketingservice.tool.response;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/show/showticketingservice/tool/response/UserAuthorityResponse.java
+++ b/src/main/java/com/show/showticketingservice/tool/response/UserAuthorityResponse.java
@@ -1,0 +1,14 @@
+package com.show.showticketingservice.tool.response;
+
+import com.show.showticketingservice.model.enumerations.UserType;
+import com.show.showticketingservice.model.responses.Authority;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class UserAuthorityResponse {
+
+    public static final ResponseEntity<Authority> OK_GENERAL = new ResponseEntity<>(new Authority(UserType.GENERAL),HttpStatus.OK);
+
+    public static final ResponseEntity<Authority> OK_MANAGER = new ResponseEntity<>(new Authority(UserType.MANAGER),HttpStatus.OK);
+
+}


### PR DESCRIPTION
회원 구분: 
- 일반회원(1)
- 관리자 회원(2)

개요:
- 서비스 관점: 같은 로그인 View에서 회원 구분 없이 로그인을 하지만 로그인 이후의 포워딩하는 View는 회원별로 상이하다.
- 서버 개발 관점: 백엔드만 구현하기 때문에 회원을 구분하기 위해 Response Body에 회원의 권한을 담아서 보낸다.

구현:
- Authority 객체 내부에 UserType Enum을 사용하여 권한을 구분
- 매번 ResponseEntity 객체를 생성하는 것을 막기 위해 권한이 담긴 ResponseEntity 상수 클래스(UserAuthorityResponse) 생성