### PR TITLE
[#26] 공연장 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/controller/VenueController.java
+++ b/src/main/java/com/show/showticketingservice/controller/VenueController.java
@@ -5,10 +5,7 @@ import com.show.showticketingservice.model.venue.Venue;
 import com.show.showticketingservice.service.VenueService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -23,6 +20,12 @@ public class VenueController {
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
     public void insertVenue(@RequestBody @Valid Venue venue) {
         venueService.insertVenue(venue);
+    }
+
+    @PutMapping("/{venueId}")
+    @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
+    public void updateVenueInfo(@PathVariable int venueId, @RequestBody @Valid Venue venueUpdateRequest) {
+        venueService.updateVenueInfo(venueId, venueUpdateRequest);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.mapper;
 
 import com.show.showticketingservice.model.venue.Venue;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 @Mapper
 public interface VenueMapper {
@@ -9,4 +10,7 @@ public interface VenueMapper {
     void insertVenue(Venue venue);
 
     boolean isVenueExists(String venueName);
+
+    void updateVenueInfo(@Param("venueId") int venueId, @Param("updateRequest") Venue venueUpdateRequest);
+
 }

--- a/src/main/java/com/show/showticketingservice/service/VenueService.java
+++ b/src/main/java/com/show/showticketingservice/service/VenueService.java
@@ -24,4 +24,8 @@ public class VenueService {
             throw new VenueAlreadyExistsException();
         }
     }
+
+    public void updateVenueInfo(int venueId, Venue venueUpdateRequest) {
+        venueMapper.updateVenueInfo(venueId, venueUpdateRequest);
+    }
 }

--- a/src/main/resources/mybatis/mappers/VenueMapper.xml
+++ b/src/main/resources/mybatis/mappers/VenueMapper.xml
@@ -13,4 +13,10 @@
         (SELECT * FROM venue WHERE name = #{venueName})
     </select>
 
+    <update id="updateVenueInfo" parameterType="map">
+        UPDATE venue
+        SET name = #{updateRequest.name}, address = #{updateRequest.address}, tel = #{updateRequest.tel}, homepage = #{updateRequest.homepage}
+        WHERE id = #{venueId}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 기능 개요
- 기존에 등록된 공연장 정보를 수정
- 관리자 권한
- 이미 공연장 정보를 유저에게 전달된 상황에서 수정 요청 시 정보의 변경 여부 확인은 Front에서 처리한다는 전제하에 전달된 정보를 바탕으로 Update 진행


## Progress
- **VenueController** - PUT 메소드(`updateVenueInfo`)에 PathVariable로 공연장 id와 RequestBody로 `Venue` 객체를 전달
- **VenueService, VenueMapper** - 공연장 정보 수정 로직인 `updateVenueInfo `메소드 추가
- 테스트 코드 관련:
    - 별도의 테스트 코드 미작성 (Postman으로 테스트 진행완료)