### PR TITLE
[#45] 공연장 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/ShowTicketingServiceApplication.java
+++ b/src/main/java/com/show/showticketingservice/ShowTicketingServiceApplication.java
@@ -2,12 +2,14 @@ package com.show.showticketingservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class ShowTicketingServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ShowTicketingServiceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ShowTicketingServiceApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -1,0 +1,48 @@
+package com.show.showticketingservice.config;
+
+import com.show.showticketingservice.tool.constants.CacheConstant;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Value("${spring.redis.cache.host}")
+    private String cacheHost;
+
+    @Value("${spring.redis.cache.port}")
+    private int cachePort;
+
+    @Bean("redisCacheConnectionFactory")
+    public RedisConnectionFactory redisCacheConnectionFactory() {
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(cacheHost, cachePort));
+    }
+
+    @Bean
+    public RedisCacheManager redisCacheManager(@Qualifier("redisCacheConnectionFactory") RedisConnectionFactory redisConnectionFactory) {
+
+        RedisCacheConfiguration redisCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
+        redisCacheConfigMap.put(CacheConstant.VENUE, redisCacheConfig.entryTtl(Duration.ofHours(2L)));
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .withInitialCacheConfigurations(redisCacheConfigMap)
+                .build();
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -31,6 +31,20 @@ public class RedisCacheConfig {
         return new LettuceConnectionFactory(new RedisStandaloneConfiguration(cacheHost, cachePort));
     }
 
+    /*
+        CacheManager:
+        - 스프링의 중앙 캐시 관리자 SPI(Service Provider Interface)로, 명명된 캐시 영역을 가져온다.
+
+        RedisCacheManager:
+        - Redis를 이용하여 캐싱을 적용할 땐 이 클래스로 CacheManager를 지원한다
+        - RedisCacheConfiguration의 기본 구성과 다른 구성이 필요한 캐시는
+          RedisCacheManager.RedisCacheManagerBuilder.withInitialCacheConfigurations(Map) 를 통해 지정 가능
+
+        CacheResolver:
+        - 캐시를 지원하는 resolver
+        - 인터셉트 된 메서드 호출에 사용할 캐시 인스턴스 결정
+        - CacheManager를 사용하여 탐색할 캐시 초기화
+     */
     @Bean
     public RedisCacheManager redisCacheManager(@Qualifier("redisCacheConnectionFactory") RedisConnectionFactory redisConnectionFactory) {
 

--- a/src/main/java/com/show/showticketingservice/config/RedisSessionConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisSessionConfig.java
@@ -13,17 +13,17 @@ import org.springframework.session.data.redis.config.annotation.web.http.EnableR
 
 @Configuration
 @EnableRedisHttpSession
-public class RedisConfig {
+public class RedisSessionConfig {
 
-    @Value("${spring.redis.host}")
-    private String redisHost;
+    @Value("${spring.redis.session.host}")
+    private String sessionHost;
 
-    @Value("${spring.redis.port}")
-    private int redisPort;
+    @Value("${spring.redis.session.port}")
+    private int sessionPort;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+        return new LettuceConnectionFactory(new RedisStandaloneConfiguration(sessionHost, sessionPort));
     }
 
     @Bean

--- a/src/main/java/com/show/showticketingservice/controller/VenueController.java
+++ b/src/main/java/com/show/showticketingservice/controller/VenueController.java
@@ -47,6 +47,11 @@ public class VenueController {
         return venueService.getAllVenues();
     }
 
+    @GetMapping("/{venueId}")
+    public VenueResponse getVenueInfo(@PathVariable int venueId) {
+        return venueService.getVenueInfo(venueId);
+    }
+
     @PostMapping("{venueId}/halls")
     public void insertVenueHalls(@RequestBody @Valid List<VenueHallRequest> venueHallRequests, @PathVariable String venueId) {
         venueHallService.insertVenueHalls(venueHallRequests, venueId);

--- a/src/main/java/com/show/showticketingservice/controller/VenueController.java
+++ b/src/main/java/com/show/showticketingservice/controller/VenueController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -43,10 +42,10 @@ public class VenueController {
         venueService.deleteVenue(venueId);
     }
 
-    @GetMapping(value = {"/list", "/list/{page}"})
+    @GetMapping
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
-    public VenueListResponse getVenueList(@PathVariable Optional<Integer> page) {
-        return venueService.getVenueList(page.orElse(1));
+    public VenueListResponse getVenueList(@RequestParam(value = "page", defaultValue = "1") int page) {
+        return venueService.getVenueList(page);
     }
 
     @GetMapping("/{venueId}")

--- a/src/main/java/com/show/showticketingservice/controller/VenueController.java
+++ b/src/main/java/com/show/showticketingservice/controller/VenueController.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
+import com.show.showticketingservice.model.venue.VenueListResponse;
 import com.show.showticketingservice.model.venue.VenueRequest;
 import com.show.showticketingservice.model.venue.VenueResponse;
 import com.show.showticketingservice.model.venueHall.VenueHallRequest;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,10 +43,10 @@ public class VenueController {
         venueService.deleteVenue(venueId);
     }
 
-    @GetMapping
+    @GetMapping(value = {"/list", "/list/{page}"})
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
-    public List<VenueResponse> getAllVenues() {
-        return venueService.getAllVenues();
+    public VenueListResponse getVenueList(@PathVariable Optional<Integer> page) {
+        return venueService.getVenueList(page.orElse(1));
     }
 
     @GetMapping("/{venueId}")

--- a/src/main/java/com/show/showticketingservice/controller/VenueController.java
+++ b/src/main/java/com/show/showticketingservice/controller/VenueController.java
@@ -1,7 +1,8 @@
 package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
-import com.show.showticketingservice.model.venue.Venue;
+import com.show.showticketingservice.model.venue.VenueRequest;
+import com.show.showticketingservice.model.venue.VenueResponse;
 import com.show.showticketingservice.model.venueHall.VenueHallRequest;
 import com.show.showticketingservice.model.venueHall.VenueHallResponse;
 import com.show.showticketingservice.service.VenueHallService;
@@ -9,6 +10,7 @@ import com.show.showticketingservice.service.VenueService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
 import javax.validation.Valid;
 import java.util.List;
 
@@ -23,13 +25,13 @@ public class VenueController {
 
     @PostMapping
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
-    public void insertVenue(@RequestBody @Valid Venue venue) {
-        venueService.insertVenue(venue);
+    public void insertVenue(@RequestBody @Valid VenueRequest venueRequest) {
+        venueService.insertVenue(venueRequest);
     }
 
     @PutMapping("/{venueId}")
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
-    public void updateVenueInfo(@PathVariable int venueId, @RequestBody @Valid Venue venueUpdateRequest) {
+    public void updateVenueInfo(@PathVariable int venueId, @RequestBody @Valid VenueRequest venueUpdateRequest) {
         venueService.updateVenueInfo(venueId, venueUpdateRequest);
     }
 
@@ -37,6 +39,12 @@ public class VenueController {
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
     public void deleteVenue(@PathVariable int venueId) {
         venueService.deleteVenue(venueId);
+    }
+
+    @GetMapping
+    @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
+    public List<VenueResponse> getAllVenues() {
+        return venueService.getAllVenues();
     }
 
     @PostMapping("{venueId}/halls")

--- a/src/main/java/com/show/showticketingservice/exception/venue/VenueListPageOutOfRangeException.java
+++ b/src/main/java/com/show/showticketingservice/exception/venue/VenueListPageOutOfRangeException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.venue;
+
+public class VenueListPageOutOfRangeException extends RuntimeException {
+
+    public VenueListPageOutOfRangeException() {
+        super("공연장 리스트 조회 페이지 범위를 벗어났습니다.");
+    }
+}

--- a/src/main/java/com/show/showticketingservice/exception/venue/VenueListPageOutOfRangeException.java
+++ b/src/main/java/com/show/showticketingservice/exception/venue/VenueListPageOutOfRangeException.java
@@ -1,8 +1,0 @@
-package com.show.showticketingservice.exception.venue;
-
-public class VenueListPageOutOfRangeException extends RuntimeException {
-
-    public VenueListPageOutOfRangeException() {
-        super("공연장 리스트 조회 페이지 범위를 벗어났습니다.");
-    }
-}

--- a/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
@@ -20,4 +20,5 @@ public interface VenueMapper {
 
     List<VenueResponse> getAllVenues();
 
+    VenueResponse getVenueInfo(int venueId);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.mapper;
 
+import com.show.showticketingservice.model.criteria.VenuePagingCriteria;
 import com.show.showticketingservice.model.venue.VenueRequest;
 import com.show.showticketingservice.model.venue.VenueResponse;
 import org.apache.ibatis.annotations.Mapper;
@@ -18,7 +19,9 @@ public interface VenueMapper {
 
     void deleteVenue(int venueId);
 
-    List<VenueResponse> getAllVenues();
+    List<VenueResponse> getVenueList(VenuePagingCriteria venuePagingCriteria);
 
     VenueResponse getVenueInfo(int venueId);
+
+    int getVenueTotalCount();
 }

--- a/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/VenueMapper.java
@@ -1,17 +1,23 @@
 package com.show.showticketingservice.mapper;
 
-import com.show.showticketingservice.model.venue.Venue;
+import com.show.showticketingservice.model.venue.VenueRequest;
+import com.show.showticketingservice.model.venue.VenueResponse;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface VenueMapper {
 
-    void insertVenue(Venue venue);
+    void insertVenue(VenueRequest venueRequest);
 
     boolean isVenueExists(String venueName);
 
-    void updateVenueInfo(@Param("venueId") int venueId, @Param("updateRequest") Venue venueUpdateRequest);
+    void updateVenueInfo(@Param("venueId") int venueId, @Param("updateRequest") VenueRequest venueUpdateRequest);
 
     void deleteVenue(int venueId);
+
+    List<VenueResponse> getAllVenues();
+
 }

--- a/src/main/java/com/show/showticketingservice/model/criteria/VenuePagingCriteria.java
+++ b/src/main/java/com/show/showticketingservice/model/criteria/VenuePagingCriteria.java
@@ -1,0 +1,19 @@
+package com.show.showticketingservice.model.criteria;
+
+import lombok.Getter;
+
+@Getter
+public class VenuePagingCriteria {
+
+    private final int page;
+
+    private final int amount = 10;
+
+    private final int startPage;
+
+    public VenuePagingCriteria(int page) {
+        this.page = page;
+        this.startPage = (page - 1) * amount;
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/model/criteria/VenuePagingCriteria.java
+++ b/src/main/java/com/show/showticketingservice/model/criteria/VenuePagingCriteria.java
@@ -5,15 +5,18 @@ import lombok.Getter;
 @Getter
 public class VenuePagingCriteria {
 
-    private final int page;
+    private int page;
+
+    private int startPage;
 
     private final int amount = 10;
-
-    private final int startPage;
 
     public VenuePagingCriteria(int page) {
         this.page = page;
         this.startPage = (page - 1) * amount;
     }
-
+    public void setPage(int page) {
+        this.page = page;
+        this.startPage = (page - 1) * amount;
+    }
 }

--- a/src/main/java/com/show/showticketingservice/model/venue/VenueListResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/venue/VenueListResponse.java
@@ -1,0 +1,16 @@
+package com.show.showticketingservice.model.venue;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class VenueListResponse {
+
+    private final int venueTotalPage;
+
+    private final List<VenueResponse> venueResponseList;
+
+}

--- a/src/main/java/com/show/showticketingservice/model/venue/VenueRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/venue/VenueRequest.java
@@ -11,7 +11,7 @@ import javax.validation.constraints.NotNull;
 @Getter
 @Builder
 @AllArgsConstructor
-public class Venue {
+public class VenueRequest {
 
     @NotBlank(message = "공연장 이름을 입력하세요.")
     @Length(max = 45, message = "공연장 이름 입력은 최대 45자까지 가능합니다.")

--- a/src/main/java/com/show/showticketingservice/model/venue/VenueResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/venue/VenueResponse.java
@@ -1,20 +1,21 @@
 package com.show.showticketingservice.model.venue;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
+@Builder
 @AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class VenueResponse {
 
-    private final int id;
+    private int id;
 
-    private final String name;
+    private String name;
 
-    private final String address;
+    private String address;
 
-    private final String tel;
+    private String tel;
 
-    private final String homepage;
+    private String homepage;
 
 }

--- a/src/main/java/com/show/showticketingservice/model/venue/VenueResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/venue/VenueResponse.java
@@ -1,0 +1,20 @@
+package com.show.showticketingservice.model.venue;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VenueResponse {
+
+    private final int id;
+
+    private final String name;
+
+    private final String address;
+
+    private final String tel;
+
+    private final String homepage;
+
+}

--- a/src/main/java/com/show/showticketingservice/service/VenueService.java
+++ b/src/main/java/com/show/showticketingservice/service/VenueService.java
@@ -4,7 +4,10 @@ import com.show.showticketingservice.exception.venue.VenueAlreadyExistsException
 import com.show.showticketingservice.mapper.VenueMapper;
 import com.show.showticketingservice.model.venue.VenueRequest;
 import com.show.showticketingservice.model.venue.VenueResponse;
+import com.show.showticketingservice.tool.constants.CacheConstant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,15 +31,22 @@ public class VenueService {
         }
     }
 
+    @CacheEvict(cacheNames = CacheConstant.VENUE, key = "#venueId")
     public void updateVenueInfo(int venueId, VenueRequest venueUpdateRequest) {
         venueMapper.updateVenueInfo(venueId, venueUpdateRequest);
     }
 
+    @CacheEvict(cacheNames = CacheConstant.VENUE, key = "#venueId")
     public void deleteVenue(int venueId) {
         venueMapper.deleteVenue(venueId);
     }
 
     public List<VenueResponse> getAllVenues() {
         return venueMapper.getAllVenues();
+    }
+
+    @Cacheable(cacheNames = CacheConstant.VENUE, key = "#venueId")
+    public VenueResponse getVenueInfo(int venueId) {
+        return venueMapper.getVenueInfo(venueId);
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/VenueService.java
+++ b/src/main/java/com/show/showticketingservice/service/VenueService.java
@@ -48,7 +48,7 @@ public class VenueService {
 
         int venueTotalCount = venueMapper.getVenueTotalCount();
 
-        int venueTotalPage = 0;
+        int venueTotalPage = 1;
 
         List<VenueResponse> venueResponseList = Collections.emptyList();
 

--- a/src/main/java/com/show/showticketingservice/service/VenueService.java
+++ b/src/main/java/com/show/showticketingservice/service/VenueService.java
@@ -2,10 +2,13 @@ package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.venue.VenueAlreadyExistsException;
 import com.show.showticketingservice.mapper.VenueMapper;
-import com.show.showticketingservice.model.venue.Venue;
+import com.show.showticketingservice.model.venue.VenueRequest;
+import com.show.showticketingservice.model.venue.VenueResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +17,9 @@ public class VenueService {
     private final VenueMapper venueMapper;
 
     @Transactional
-    public void insertVenue(Venue venue) {
-        checkVenueExists(venue.getName());
-        venueMapper.insertVenue(venue);
+    public void insertVenue(VenueRequest venueRequest) {
+        checkVenueExists(venueRequest.getName());
+        venueMapper.insertVenue(venueRequest);
     }
 
     public void checkVenueExists(String venueName) {
@@ -25,11 +28,15 @@ public class VenueService {
         }
     }
 
-    public void updateVenueInfo(int venueId, Venue venueUpdateRequest) {
+    public void updateVenueInfo(int venueId, VenueRequest venueUpdateRequest) {
         venueMapper.updateVenueInfo(venueId, venueUpdateRequest);
     }
 
     public void deleteVenue(int venueId) {
         venueMapper.deleteVenue(venueId);
+    }
+
+    public List<VenueResponse> getAllVenues() {
+        return venueMapper.getAllVenues();
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/VenueService.java
+++ b/src/main/java/com/show/showticketingservice/service/VenueService.java
@@ -1,10 +1,9 @@
 package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.venue.VenueAlreadyExistsException;
-import com.show.showticketingservice.exception.venue.VenueListPageOutOfRangeException;
 import com.show.showticketingservice.mapper.VenueMapper;
-import com.show.showticketingservice.model.venue.VenueListResponse;
 import com.show.showticketingservice.model.criteria.VenuePagingCriteria;
+import com.show.showticketingservice.model.venue.VenueListResponse;
 import com.show.showticketingservice.model.venue.VenueRequest;
 import com.show.showticketingservice.model.venue.VenueResponse;
 import com.show.showticketingservice.tool.constants.CacheConstant;
@@ -14,6 +13,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -45,26 +45,24 @@ public class VenueService {
     }
 
     public VenueListResponse getVenueList(int page) {
-        if (page <= 0)
-            throw new VenueListPageOutOfRangeException();
 
         int venueTotalCount = venueMapper.getVenueTotalCount();
 
         int venueTotalPage = 0;
 
-        List<VenueResponse> venueResponseList = null;
-
-        VenuePagingCriteria pagingCriteria = new VenuePagingCriteria(page);
+        List<VenueResponse> venueResponseList = Collections.emptyList();
 
         if (venueTotalCount > 0) {
+            VenuePagingCriteria pagingCriteria = new VenuePagingCriteria(page);
+
             int mod = venueTotalCount % pagingCriteria.getAmount();
 
             venueTotalPage = venueTotalCount / pagingCriteria.getAmount() + (mod != 0 ? 1 : 0);
 
-            if (page <= venueTotalPage)
-                venueResponseList = venueMapper.getVenueList(pagingCriteria);
-            else
-                throw new VenueListPageOutOfRangeException();
+            if (page <= 0 || venueTotalPage < page)
+                pagingCriteria.setPage(1);
+
+            venueResponseList = venueMapper.getVenueList(pagingCriteria);
         }
 
         return new VenueListResponse(venueTotalPage, venueResponseList);

--- a/src/main/java/com/show/showticketingservice/tool/advice/VenueExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/VenueExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.tool.advice;
 
 import com.show.showticketingservice.exception.venue.VenueAlreadyExistsException;
+import com.show.showticketingservice.exception.venue.VenueListPageOutOfRangeException;
 import com.show.showticketingservice.exception.venueHall.VenueHallAlreadyExistsException;
 import com.show.showticketingservice.exception.venueHall.SameVenueHallAdditionException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
@@ -32,6 +33,13 @@ public class VenueExceptionAdvice {
     @ExceptionHandler(VenueHallAlreadyExistsException.class)
     public ResponseEntity<ExceptionResponse> venueHallAlreadyExistsException(final VenueHallAlreadyExistsException e, WebRequest request) {
         log.error("venueHall registration failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(VenueListPageOutOfRangeException.class)
+    public ResponseEntity<ExceptionResponse> VenueListPageOutOfRangeException(final VenueListPageOutOfRangeException e, WebRequest request) {
+        log.error("venue list acquisition failed", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/show/showticketingservice/tool/advice/VenueExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/VenueExceptionAdvice.java
@@ -1,7 +1,6 @@
 package com.show.showticketingservice.tool.advice;
 
 import com.show.showticketingservice.exception.venue.VenueAlreadyExistsException;
-import com.show.showticketingservice.exception.venue.VenueListPageOutOfRangeException;
 import com.show.showticketingservice.exception.venueHall.VenueHallAlreadyExistsException;
 import com.show.showticketingservice.exception.venueHall.SameVenueHallAdditionException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
@@ -33,13 +32,6 @@ public class VenueExceptionAdvice {
     @ExceptionHandler(VenueHallAlreadyExistsException.class)
     public ResponseEntity<ExceptionResponse> venueHallAlreadyExistsException(final VenueHallAlreadyExistsException e, WebRequest request) {
         log.error("venueHall registration failed", e);
-        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
-        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
-    }
-
-    @ExceptionHandler(VenueListPageOutOfRangeException.class)
-    public ResponseEntity<ExceptionResponse> VenueListPageOutOfRangeException(final VenueListPageOutOfRangeException e, WebRequest request) {
-        log.error("venue list acquisition failed", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
@@ -1,0 +1,7 @@
+package com.show.showticketingservice.tool.constants;
+
+public class CacheConstant {
+
+    public static final String VENUE = "venue";
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,5 +10,9 @@ mybatis.type-aliases-package=com.show.showticketingservice.mapper
 mybatis.mapper-locations=mybatis/mappers/*.xml
 
 # Redis Session
-spring.redis.host=localhost
-spring.redis.port=6379
+spring.redis.session.host=localhost
+spring.redis.session.port=6379
+
+# Redis Cache
+spring.redis.cache.host=localhost
+spring.redis.cache.port=6380

--- a/src/main/resources/mybatis/mappers/VenueMapper.xml
+++ b/src/main/resources/mybatis/mappers/VenueMapper.xml
@@ -29,4 +29,10 @@
         FROM venue
     </select>
 
+    <select id="getVenueInfo" resultType="com.show.showticketingservice.model.venue.VenueResponse">
+        SELECT id, name, address, tel, homepage
+        FROM venue
+        WHERE id = #{venueId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mappers/VenueMapper.xml
+++ b/src/main/resources/mybatis/mappers/VenueMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="com.show.showticketingservice.mapper.VenueMapper">
 
-    <insert id="insertVenue" parameterType="com.show.showticketingservice.model.venue.Venue">
+    <insert id="insertVenue" parameterType="com.show.showticketingservice.model.venue.VenueRequest">
         INSERT INTO venue(name, address, tel, homepage)
         VALUES(#{name}, #{address}, #{tel}, #{homepage})
     </insert>
@@ -23,5 +23,10 @@
         DELETE FROM venue
         WHERE id = #{venueId}
     </delete>
+
+    <select id="getAllVenues" resultType="com.show.showticketingservice.model.venue.VenueResponse">
+        SELECT id, name, address, tel, homepage
+        FROM venue
+    </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mappers/VenueMapper.xml
+++ b/src/main/resources/mybatis/mappers/VenueMapper.xml
@@ -24,15 +24,22 @@
         WHERE id = #{venueId}
     </delete>
 
-    <select id="getAllVenues" resultType="com.show.showticketingservice.model.venue.VenueResponse">
+    <select id="getVenueList" parameterType="com.show.showticketingservice.model.criteria.VenuePagingCriteria"
+            resultType="com.show.showticketingservice.model.venue.VenueResponse">
         SELECT id, name, address, tel, homepage
         FROM venue
+        LIMIT #{startPage}, #{amount}
     </select>
 
     <select id="getVenueInfo" resultType="com.show.showticketingservice.model.venue.VenueResponse">
         SELECT id, name, address, tel, homepage
         FROM venue
         WHERE id = #{venueId}
+    </select>
+
+    <select id="getVenueTotalCount" resultType="int">
+        SELECT COUNT(*)
+        FROM venue
     </select>
 
 </mapper>

--- a/src/test/java/com/show/showticketingservice/controller/VenueControllerTest.java
+++ b/src/test/java/com/show/showticketingservice/controller/VenueControllerTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.show.showticketingservice.model.enumerations.UserType;
 import com.show.showticketingservice.model.user.UserRequest;
 import com.show.showticketingservice.model.user.UserSession;
-import com.show.showticketingservice.model.venue.Venue;
+import com.show.showticketingservice.model.venue.VenueRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ class VenueControllerTest {
 
     private UserRequest generalUser;
 
-    private Venue venue;
+    private VenueRequest venueRequest;
 
     private MockMvc mvc;
 
@@ -51,7 +51,7 @@ class VenueControllerTest {
 
         generalUser = new UserRequest("testId1", "testPW1234#", "Test User", "010-1111-1111", "user1@example.com", "Seoul, South Korea", UserType.GENERAL);
 
-        venue = new Venue("공연장1", "서울시", "02-1212-3434", "www.공연장1.co.kr");
+        venueRequest = new VenueRequest("공연장1", "서울시", "02-1212-3434", "www.공연장1.co.kr");
 
         mvc = MockMvcBuilders.webAppContextSetup(context).build();
     }
@@ -67,7 +67,7 @@ class VenueControllerTest {
     public void normalVenueInsertion() throws Exception {
         loginUser(managerAccount);
 
-        String content = objectMapper.writeValueAsString(venue);
+        String content = objectMapper.writeValueAsString(venueRequest);
 
         mvc.perform(post("/venues")
                 .content(content)
@@ -81,7 +81,7 @@ class VenueControllerTest {
     @Test
     @DisplayName("로그인 하지 않은 상태로 공연장 정보 추가 요청 시 실패 - Http Status 401 (Unauthorized)")
     public void insertVenueWithoutLogin() throws Exception {
-        String content = objectMapper.writeValueAsString(venue);
+        String content = objectMapper.writeValueAsString(venueRequest);
 
         mvc.perform(post("/venues")
                 .content(content)
@@ -96,7 +96,7 @@ class VenueControllerTest {
     public void insertVenueByGeneralUser() throws Exception {
         loginUser(generalUser);
 
-        String content = objectMapper.writeValueAsString(venue);
+        String content = objectMapper.writeValueAsString(venueRequest);
 
         mvc.perform(post("/venues")
                 .content(content)
@@ -112,7 +112,7 @@ class VenueControllerTest {
     public void insertDuplicatedVenue() throws Exception {
         loginUser(managerAccount);
 
-        String content = objectMapper.writeValueAsString(venue);
+        String content = objectMapper.writeValueAsString(venueRequest);
 
         mvc.perform(post("/venues")
                 .content(content)
@@ -134,11 +134,11 @@ class VenueControllerTest {
     @Test
     @DisplayName("주요 공연장 정보(ex. 전화번호)가 누락된 상태로 정보 추가 요청 시 실패 - Http Status 400 (Bad Request)")
     public void insertVenueWithMissingInfo() throws Exception {
-        Venue incompleteVenue = Venue.builder()
-                .name(venue.getName())
-                .address(venue.getAddress())
+        VenueRequest incompleteVenue = VenueRequest.builder()
+                .name(venueRequest.getName())
+                .address(venueRequest.getAddress())
                 .tel("")
-                .homepage(venue.getHomepage())
+                .homepage(venueRequest.getHomepage())
                 .build();
 
         loginUser(managerAccount);


### PR DESCRIPTION
#45 

## 기능 개요
1. **공연장 관리 페이지에서 모든 공연장 정보 조회**
    - 관리자 권한
2. **공연장 리스트에서 특정 공연장을 선택했을 때 해당 공연장 상세 정보 확인**
    - 해당 공연장의 공연 홀 정보도 반환 (별도의 이슈에서 진행)
3. **캐싱 적용**
    - 빈번히 요청되는 데이터를 캐시로 저장하여 동일한 요청이 왔을 때 빠르게 응답
    - 적용 데이터: 공연장 정보
4. **모든 공연장 정보 조회 기능에 페이징 적용**
    - 공연장 정보가 많을 경우 모든 공연장 정보를 반환할 때 문제 발생
    - 페이지를 나눠 특정 범위 만큼만 해당 페이지의 공연장 리스트 반환

<br>

## Progress
1. **모든 공연장 정보 조회**
    - **VenueController** - GET 메소드로 DB에 저장되어 있는 모든 공연장 정보를 리턴
    - **VenueService, VenueMapper** - getAllVenues: venue 테이블의 모든 공연장 정보 리턴
    - Venue 객체를 Request 용과 Response 용 객체로 구분

2. **특정 공연장 정보 조회 기능**
    - venueId를 pathVariable로 받아 해당 공연장 정보를 반환

3. **캐싱 기능 구현**
    - 글로벌 캐싱 적용:
        - RedisCacheConfig 클래스에서 캐싱 관련 설정
        - redis를 캐시 저장소로 사용 (port: 6380 / 기존 세션 저장소는 port: 6379)
    - **Jackson**을 이용하여 Serialization 수행 (GenericJackson2JsonRedisSerializer)
    - 캐싱 적용 데이터: 공연장 정보 
        - 공연장 정보는 거의 바뀌지 않는다. 
        - durationTime: 2 hours
        - VenueResponse 클래스의 필드에 대해 final 접근제어자 삭제
            - Desrialization을 수행하기 위해선 VenueResponse 객체를 기본 생성자를 통해서 생성 필요

4. **모든 공연장 정보 조회 기능에 페이징 적용**
    - 공연장 리스트 조회 페이지 번호를 RequestParam으로 전달
    - 페이지 번호를 명시하지 않을 시 default 값 1 설정 
    - 페이지 값이 유효하지 않은 요청일 경우 1 페이지 반환

5. **Test**
    - 로컬에 따라 DB에 저장된 데이터가 상이하므로 테스트는 Postman으로 진행
    - 테스트 코드 미작성