### PR TITLE
[#34] 공연 정보 추가 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ target/
 !.mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+files/
+
 
 ### STS ###
 .apt_generated

--- a/etc/show_ticketing_service.sql
+++ b/etc/show_ticketing_service.sql
@@ -56,3 +56,14 @@ CREATE INDEX performance_Index ON performance
 (
     title
 );
+
+CREATE TABLE performanceTime
+(
+    `id`             INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
+    `performanceId`  INT UNSIGNED    NOT NULL,
+    `startTime`      DATETIME        NOT NULL,
+    `endTime`        DATETIME        NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (performanceId) REFERENCES performance(id)
+    ON DELETE CASCADE
+);

--- a/etc/show_ticketing_service.sql
+++ b/etc/show_ticketing_service.sql
@@ -21,10 +21,7 @@ CREATE TABLE venue
     PRIMARY KEY (id)
 );
 
-CREATE INDEX venue_Index ON venue
-(
-    name
-);
+CREATE INDEX venue_Index ON venue(name);
 
 CREATE TABLE venueHall(
    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -52,18 +49,18 @@ CREATE TABLE performance
     FOREIGN KEY (hallId) REFERENCES venueHall(id)
 );
 
-CREATE INDEX performance_Index ON performance
-(
-    title
-);
+CREATE INDEX performance_Index ON performance(title);
 
 CREATE TABLE performanceTime
 (
     `id`             INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
     `performanceId`  INT UNSIGNED    NOT NULL,
+    `hallId`         INT UNSIGNED    NOT NULL,
     `startTime`      DATETIME        NOT NULL,
     `endTime`        DATETIME        NOT NULL,
     PRIMARY KEY (id),
-    FOREIGN KEY (performanceId) REFERENCES performance(id)
-    ON DELETE CASCADE
+    FOREIGN KEY (performanceId) REFERENCES performance(id) ON DELETE CASCADE,
+    FOREIGN KEY (hallId)        REFERENCES venueHall(id)
 );
+
+CREATE INDEX performanceTime_Index ON performanceTime(startTime);

--- a/etc/show_ticketing_service.sql
+++ b/etc/show_ticketing_service.sql
@@ -60,3 +60,8 @@ CREATE TABLE performance
     FOREIGN KEY (venueId) REFERENCES venue(id),
     FOREIGN KEY (hallId) REFERENCES venueHall(id)
 );
+
+CREATE INDEX performance_Index ON performance
+(
+    title
+);

--- a/etc/show_ticketing_service.sql
+++ b/etc/show_ticketing_service.sql
@@ -37,26 +37,17 @@ CREATE TABLE venueHall(
    FOREIGN KEY (venueId) REFERENCES venue(id)
 );
 
-CREATE TABLE posterImage
-(
-    `id`        INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
-    `fileName`  VARCHAR(100)    NULL,
-    `path`      VARCHAR(255)    NOT NULL,
-    PRIMARY KEY (id)
-);
-
 CREATE TABLE performance
 (
-    `id`        INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
-    `title`     VARCHAR(50)     NOT NULL,
-    `posterId`  INT UNSIGNED    NULL,
-    `detail`    VARCHAR(500)    NULL,
-    `ageLimit`  INT             NULL,
-    `showType`  INT(3)          NOT NULL,
-    `venueId`   INT UNSIGNED    NOT NULL,
-    `hallId`    INT UNSIGNED    NOT NULL,
+    `id`            INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
+    `title`         VARCHAR(50)     NOT NULL,
+    `imageFilePath` VARCHAR(255)    NULL,
+    `detail`        VARCHAR(500)    NULL,
+    `ageLimit`      INT             NULL,
+    `showType`      INT(3)          NOT NULL,
+    `venueId`       INT UNSIGNED    NOT NULL,
+    `hallId`        INT UNSIGNED    NOT NULL,
     PRIMARY KEY (id),
-    FOREIGN KEY (posterId) REFERENCES posterImage(id),
     FOREIGN KEY (venueId) REFERENCES venue(id),
     FOREIGN KEY (hallId) REFERENCES venueHall(id)
 );

--- a/etc/show_ticketing_service.sql
+++ b/etc/show_ticketing_service.sql
@@ -36,3 +36,27 @@ CREATE TABLE venueHall(
    PRIMARY KEY (id),
    FOREIGN KEY (venueId) REFERENCES venue(id)
 );
+
+CREATE TABLE posterImage
+(
+    `id`        INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
+    `fileName`  VARCHAR(100)    NULL,
+    `path`      VARCHAR(255)    NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE performance
+(
+    `id`        INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
+    `title`     VARCHAR(50)     NOT NULL,
+    `posterId`  INT UNSIGNED    NULL,
+    `detail`    VARCHAR(500)    NULL,
+    `ageLimit`  INT             NULL,
+    `showType`  INT(3)          NOT NULL,
+    `venueId`   INT UNSIGNED    NOT NULL,
+    `hallId`    INT UNSIGNED    NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (posterId) REFERENCES posterImage(id),
+    FOREIGN KEY (venueId) REFERENCES venue(id),
+    FOREIGN KEY (hallId) REFERENCES venueHall(id)
+);

--- a/src/main/java/com/show/showticketingservice/config/MyBatisConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/MyBatisConfig.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.config;
 
+import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.enumerations.UserType;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.mybatis.spring.SqlSessionFactoryBean;
@@ -19,7 +20,7 @@ public class MyBatisConfig {
 
         sqlSessionFactoryBean.setDataSource(dataSource);
         sqlSessionFactoryBean.setMapperLocations(resolver.getResources("mybatis/mappers/*.xml"));
-        sqlSessionFactoryBean.setTypeHandlers(new UserType.TypeHandler());
+        sqlSessionFactoryBean.setTypeHandlers(new UserType.TypeHandler(), new ShowType.TypeHandler());
 
         return sqlSessionFactoryBean.getObject();
     }

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -1,0 +1,28 @@
+package com.show.showticketingservice.controller;
+
+import com.show.showticketingservice.model.enumerations.AccessRoles;
+import com.show.showticketingservice.model.performance.PerformanceRequest;
+import com.show.showticketingservice.service.PerformanceService;
+import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/performances")
+public class PerformanceController {
+
+    private final PerformanceService performanceService;
+
+    @PostMapping
+    @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
+    public void insertPerformance(@RequestBody @Valid PerformanceRequest performanceRequest) {
+        performanceService.insertPerformance(performanceRequest);
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -5,10 +5,8 @@ import com.show.showticketingservice.model.performance.PerformanceRequest;
 import com.show.showticketingservice.service.PerformanceService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 
@@ -23,6 +21,12 @@ public class PerformanceController {
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
     public void insertPerformance(@RequestBody @Valid PerformanceRequest performanceRequest) {
         performanceService.insertPerformance(performanceRequest);
+    }
+
+    @PutMapping("/{performanceId}/image")
+    @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
+    public void updatePosterImage(@PathVariable int performanceId,  @RequestParam("image") MultipartFile image) {
+        performanceService.updatePosterImage(performanceId, image);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
+import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
 import com.show.showticketingservice.service.PerformanceService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,8 +27,14 @@ public class PerformanceController {
 
     @PutMapping("/{performanceId}/image")
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
-    public void updatePosterImage(@PathVariable int performanceId,  @RequestParam("image") MultipartFile image) {
+    public void updatePosterImage(@PathVariable int performanceId, @RequestParam("image") MultipartFile image) {
         performanceService.updatePosterImage(performanceId, image);
+    }
+
+    @PostMapping("/{performanceId}/times")
+    @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
+    public void insertPerfTime(@RequestBody @Valid List<PerformanceTimeRequest> performanceTimeRequests, @PathVariable int performanceId) {
+        performanceService.insertPerformanceTimes(performanceTimeRequests, performanceId);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/exception/file/InvalidFileTypeException.java
+++ b/src/main/java/com/show/showticketingservice/exception/file/InvalidFileTypeException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.file;
+
+public class InvalidFileTypeException extends RuntimeException {
+
+    public InvalidFileTypeException() {
+        super("지원되지 않는 파일 형식입니다.");
+    }
+}

--- a/src/main/java/com/show/showticketingservice/exception/performance/PerformanceAlreadyExistsException.java
+++ b/src/main/java/com/show/showticketingservice/exception/performance/PerformanceAlreadyExistsException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.performance;
+
+public class PerformanceAlreadyExistsException extends RuntimeException {
+
+    public PerformanceAlreadyExistsException() {
+        super("동일한 이름의 공연이 존재합니다.");
+    }
+}

--- a/src/main/java/com/show/showticketingservice/exception/performance/PerformanceTimeConflictException.java
+++ b/src/main/java/com/show/showticketingservice/exception/performance/PerformanceTimeConflictException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.performance;
+
+public class PerformanceTimeConflictException extends RuntimeException {
+
+    public PerformanceTimeConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -1,0 +1,14 @@
+package com.show.showticketingservice.mapper;
+
+import com.show.showticketingservice.model.enumerations.ShowType;
+import com.show.showticketingservice.model.performance.PerformanceRequest;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PerformanceMapper {
+
+    void insertPerformance(PerformanceRequest performanceRequest);
+
+    boolean isPerformanceExists(String title, ShowType showType);
+
+}

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -12,4 +12,6 @@ public interface PerformanceMapper {
     boolean isPerformanceExists(String title, ShowType showType);
 
     void updatePerfImagePath(int performanceId, String filePath);
+
+    String getImagePath(int performanceId);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -11,4 +11,5 @@ public interface PerformanceMapper {
 
     boolean isPerformanceExists(String title, ShowType showType);
 
+    void updatePerfImagePath(int performanceId, String filePath);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
@@ -10,6 +10,6 @@ public interface PerformanceTimeMapper {
 
     void insertPerformanceTimes(List<PerformanceTimeRequest> performanceTimeRequests, int performanceId);
 
-    List<PerformanceTimeRequest> getPerfTimes(int performanceId);
+    List<PerformanceTimeRequest> getPerfTimes(int performanceId, List<PerformanceTimeRequest> performanceTimeRequests);
 
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
@@ -10,4 +10,6 @@ public interface PerformanceTimeMapper {
 
     void insertPerformanceTimes(List<PerformanceTimeRequest> performanceTimeRequests, int performanceId);
 
+    List<PerformanceTimeRequest> getPerfTimes(int performanceId);
+
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
@@ -1,0 +1,13 @@
+package com.show.showticketingservice.mapper;
+
+import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface PerformanceTimeMapper {
+
+    void insertPerformanceTimes(List<PerformanceTimeRequest> performanceTimeRequests, int performanceId);
+
+}

--- a/src/main/java/com/show/showticketingservice/model/enumerations/ShowType.java
+++ b/src/main/java/com/show/showticketingservice/model/enumerations/ShowType.java
@@ -1,0 +1,44 @@
+package com.show.showticketingservice.model.enumerations;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.show.showticketingservice.tool.handler.EnumTypeHandler;
+import lombok.RequiredArgsConstructor;
+import org.apache.ibatis.type.MappedTypes;
+
+@RequiredArgsConstructor
+public enum ShowType implements EnumType {
+
+    MUSICAL(1),
+    THEATRICAL(2),
+    CONCERT(3);
+
+    private final int value;
+
+    @JsonCreator
+    public static ShowType valueOf(int value) {
+        switch (value) {
+            case 1:
+                return MUSICAL;
+            case 2:
+                return THEATRICAL;
+            case 3:
+                return CONCERT;
+            default:
+                throw new AssertionError("Unknown value: " + value);
+        }
+    }
+
+    @Override
+    @JsonValue
+    public int getValue() {
+        return this.value;
+    }
+
+    @MappedTypes(ShowType.class)
+    public static class TypeHandler extends EnumTypeHandler<ShowType> {
+        public TypeHandler() {
+            super(ShowType.class);
+        }
+    }
+}

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceRequest.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.model.performance;
 
 import com.show.showticketingservice.model.enumerations.ShowType;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.lang.Nullable;
@@ -10,15 +11,13 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class PerformanceRequest {
 
     @NotBlank(message = "공연 제목을 입력하세요.")
     @Length(max = 50, message = "제목은 50자 내로 입력하세요.")
     private final String title;
-
-    @Nullable
-    private final String imageFilePath;
 
     @Nullable
     @Length(max = 500, message = "공연 설명은 500자 내로 입력하세요.")

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceRequest.java
@@ -18,7 +18,7 @@ public class PerformanceRequest {
     private final String title;
 
     @Nullable
-    private final int posterId;
+    private final String imageFilePath;
 
     @Nullable
     @Length(max = 500, message = "공연 설명은 500자 내로 입력하세요.")

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceRequest.java
@@ -1,0 +1,39 @@
+package com.show.showticketingservice.model.performance;
+
+import com.show.showticketingservice.model.enumerations.ShowType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class PerformanceRequest {
+
+    @NotBlank(message = "공연 제목을 입력하세요.")
+    @Length(max = 50, message = "제목은 50자 내로 입력하세요.")
+    private final String title;
+
+    @Nullable
+    private final int posterId;
+
+    @Nullable
+    @Length(max = 500, message = "공연 설명은 500자 내로 입력하세요.")
+    private final String detail;
+
+    @Nullable
+    private final int ageLimit;
+
+    @NotNull(message = "공연 타입을 입력하세요.")
+    private final ShowType showType;
+
+    @NotNull(message = "공연장 ID를 입력하세요.")
+    private final int venueId;
+
+    @NotNull(message = "공연홀 ID를 입력하세요.")
+    private final int hallId;
+
+}

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceTimeRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceTimeRequest.java
@@ -1,10 +1,12 @@
 package com.show.showticketingservice.model.performance;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
+@Getter
 @AllArgsConstructor
 public class PerformanceTimeRequest {
 

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceTimeRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceTimeRequest.java
@@ -1,0 +1,19 @@
+package com.show.showticketingservice.model.performance;
+
+import lombok.AllArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@AllArgsConstructor
+public class PerformanceTimeRequest {
+
+    @NotBlank
+    @Pattern(regexp = "^(\\d{14})$", message = "14자리의 숫자로만 입력하세요. 입력 예(2021년01월31일 14시00분00초) -> 20210131140000")
+    private final String startTime;
+
+    @NotBlank
+    @Pattern(regexp = "^(\\d{14})$", message = "14자리의 숫자로만 입력하세요. 입력 예(2021년01월31일 14시00분00초) -> 20210131140000")
+    private final String endTime;
+
+}

--- a/src/main/java/com/show/showticketingservice/service/FileService.java
+++ b/src/main/java/com/show/showticketingservice/service/FileService.java
@@ -1,63 +1,15 @@
 package com.show.showticketingservice.service;
 
-import com.show.showticketingservice.exception.file.InvalidFileTypeException;
-import com.show.showticketingservice.tool.util.FileUtil;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+public interface FileService {
 
-@Service
-@RequiredArgsConstructor
-public class FileService {
+    String registerPosterImage(MultipartFile image);
 
-    @Value("${spring.servlet.multipart.location}")
-    private String fileUploadPath;
+    String saveImage(String fileName, MultipartFile image);
 
-    private final FileUtil fileUtil;
+    void deleteFile(String imagePath);
 
-    public String registerPosterImage(MultipartFile image) {
+    void checkFileContentType(MultipartFile image);
 
-        String fileName = fileUtil.renameFile(image.getOriginalFilename());
-
-        fileUtil.pathCheck(fileUploadPath);
-
-        return saveImage(fileName, image);
-    }
-
-    private String saveImage(String fileName, MultipartFile image) {
-        StringBuilder filePath = new StringBuilder()
-                .append(fileUploadPath)
-                .append(File.separator)
-                .append(fileName);
-
-        Path path = Paths.get(filePath.toString()).toAbsolutePath().normalize();
-
-        try {
-            image.transferTo(new File(path.toString()));
-
-            return path.toString();
-        } catch (IOException e) {
-            String eMessage = String.format("' %s' 이미지 파일 업로드에 실패하였습니다.", fileName);
-            throw new RuntimeException(eMessage);
-        }
-    }
-
-    public void deleteFile(String imagePath) {
-        new File(imagePath).delete();
-    }
-
-    public void checkFileContentType(MultipartFile image) {
-        String contentType = image.getContentType();
-
-        if (contentType == null || !fileUtil.isImageFile(contentType)) {
-            throw new InvalidFileTypeException();
-        }
-
-    }
 }

--- a/src/main/java/com/show/showticketingservice/service/FileService.java
+++ b/src/main/java/com/show/showticketingservice/service/FileService.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.service;
 
+import com.show.showticketingservice.exception.file.InvalidFileTypeException;
 import com.show.showticketingservice.tool.util.FileUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,5 +50,14 @@ public class FileService {
 
     public void deleteFile(String imagePath) {
         new File(imagePath).delete();
+    }
+
+    public void checkFileContentType(MultipartFile image) {
+        String contentType = image.getContentType();
+
+        if(contentType == null || !fileUtil.isImageFile(contentType)) {
+            throw new InvalidFileTypeException();
+        }
+
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/FileService.java
+++ b/src/main/java/com/show/showticketingservice/service/FileService.java
@@ -47,4 +47,7 @@ public class FileService {
         }
     }
 
+    public void deleteFile(String imagePath) {
+        new File(imagePath).delete();
+    }
 }

--- a/src/main/java/com/show/showticketingservice/service/FileService.java
+++ b/src/main/java/com/show/showticketingservice/service/FileService.java
@@ -1,0 +1,50 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.tool.util.FileUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+
+    @Value("${spring.servlet.multipart.location}")
+    private String fileUploadPath;
+
+    private final FileUtil fileUtil;
+
+    public String registerPosterImage(MultipartFile image) {
+
+        String fileName = fileUtil.renameFile(image.getOriginalFilename());
+
+        fileUtil.pathCheck(fileUploadPath);
+
+        return saveImage(fileName, image);
+    }
+
+    private String saveImage(String fileName, MultipartFile image) {
+        StringBuilder filePath = new StringBuilder()
+                .append(fileUploadPath)
+                .append(File.separator)
+                .append(fileName);
+
+        Path path = Paths.get(filePath.toString()).toAbsolutePath().normalize();
+
+        try {
+            image.transferTo(new File(path.toString()));
+
+            return path.toString();
+        } catch (IOException e) {
+            String eMessage = String.format("' %s' 이미지 파일 업로드에 실패하였습니다.", fileName);
+            throw new RuntimeException(eMessage);
+        }
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/service/FileService.java
+++ b/src/main/java/com/show/showticketingservice/service/FileService.java
@@ -4,9 +4,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
 
-    String registerImage(MultipartFile image);
-
-    String saveFile(String fileName, MultipartFile image);
+    String saveFile(MultipartFile image);
 
     void deleteFile(String imagePath);
 

--- a/src/main/java/com/show/showticketingservice/service/FileService.java
+++ b/src/main/java/com/show/showticketingservice/service/FileService.java
@@ -55,7 +55,7 @@ public class FileService {
     public void checkFileContentType(MultipartFile image) {
         String contentType = image.getContentType();
 
-        if(contentType == null || !fileUtil.isImageFile(contentType)) {
+        if (contentType == null || !fileUtil.isImageFile(contentType)) {
             throw new InvalidFileTypeException();
         }
 

--- a/src/main/java/com/show/showticketingservice/service/FileService.java
+++ b/src/main/java/com/show/showticketingservice/service/FileService.java
@@ -4,9 +4,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 public interface FileService {
 
-    String registerPosterImage(MultipartFile image);
+    String registerImage(MultipartFile image);
 
-    String saveImage(String fileName, MultipartFile image);
+    String saveFile(String fileName, MultipartFile image);
 
     void deleteFile(String imagePath);
 

--- a/src/main/java/com/show/showticketingservice/service/LocalFileService.java
+++ b/src/main/java/com/show/showticketingservice/service/LocalFileService.java
@@ -1,0 +1,65 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.exception.file.InvalidFileTypeException;
+import com.show.showticketingservice.tool.util.FileUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Service
+@RequiredArgsConstructor
+public class LocalFileService implements FileService {
+
+    @Value("${spring.servlet.multipart.location}")
+    private String fileUploadPath;
+
+    @Override
+    public String registerPosterImage(MultipartFile image) {
+
+        String fileName = FileUtil.renameFile(image.getOriginalFilename());
+
+        FileUtil.pathCheck(fileUploadPath);
+
+        return saveImage(fileName, image);
+    }
+
+    @Override
+    public String saveImage(String fileName, MultipartFile image) {
+        StringBuilder filePath = new StringBuilder()
+                .append(fileUploadPath)
+                .append(File.separator)
+                .append(fileName);
+
+        Path path = Paths.get(filePath.toString()).toAbsolutePath().normalize();
+
+        try {
+            image.transferTo(new File(path.toString()));
+
+            return path.toString();
+        } catch (IOException e) {
+            String eMessage = String.format("' %s' 이미지 파일 업로드에 실패하였습니다.", fileName);
+            throw new RuntimeException(eMessage, e);
+        }
+    }
+
+    @Override
+    public void deleteFile(String imagePath) {
+        new File(imagePath).delete();
+    }
+
+    @Override
+    public void checkFileContentType(MultipartFile image) {
+        String contentType = image.getContentType();
+
+        if (contentType == null || !FileUtil.isImageFile(contentType)) {
+            throw new InvalidFileTypeException();
+        }
+
+    }
+}

--- a/src/main/java/com/show/showticketingservice/service/LocalFileService.java
+++ b/src/main/java/com/show/showticketingservice/service/LocalFileService.java
@@ -20,17 +20,17 @@ public class LocalFileService implements FileService {
     private String fileUploadPath;
 
     @Override
-    public String registerPosterImage(MultipartFile image) {
+    public String registerImage(MultipartFile image) {
 
         String fileName = FileUtil.renameFile(image.getOriginalFilename());
 
         FileUtil.pathCheck(fileUploadPath);
 
-        return saveImage(fileName, image);
+        return saveFile(fileName, image);
     }
 
     @Override
-    public String saveImage(String fileName, MultipartFile image) {
+    public String saveFile(String fileName, MultipartFile image) {
         StringBuilder filePath = new StringBuilder()
                 .append(fileUploadPath)
                 .append(File.separator)

--- a/src/main/java/com/show/showticketingservice/service/LocalFileService.java
+++ b/src/main/java/com/show/showticketingservice/service/LocalFileService.java
@@ -20,17 +20,12 @@ public class LocalFileService implements FileService {
     private String fileUploadPath;
 
     @Override
-    public String registerImage(MultipartFile image) {
+    public String saveFile(MultipartFile image) {
 
         String fileName = FileUtil.renameFile(image.getOriginalFilename());
 
         FileUtil.pathCheck(fileUploadPath);
 
-        return saveFile(fileName, image);
-    }
-
-    @Override
-    public String saveFile(String fileName, MultipartFile image) {
         StringBuilder filePath = new StringBuilder()
                 .append(fileUploadPath)
                 .append(File.separator)

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -7,7 +7,6 @@ import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
 import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,9 +16,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class PerformanceService {
-
-    @Value("${spring.servlet.multipart.location}")
-    private String fileUploadPath;
 
     private final PerformanceMapper performanceMapper;
 

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -48,7 +48,7 @@ public class PerformanceService {
             fileService.deleteFile(imagePath);
         }
 
-        imagePath = fileService.registerPosterImage(image);
+        imagePath = fileService.registerImage(image);
         performanceMapper.updatePerfImagePath(performanceId, imagePath);
     }
 

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -34,6 +34,9 @@ public class PerformanceService {
     }
 
     public void updatePosterImage(int performanceId, MultipartFile image) {
+
+        fileService.checkFileContentType(image);
+
         String imagePath = performanceMapper.getImagePath(performanceId);
 
         if(imagePath != null) {

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -113,7 +113,7 @@ public class PerformanceService {
 
     private void checkPerfTimeRequestConflict(List<PerformanceTimeRequest> performanceTimeRequests) {
         /*
-        공연 스케줄 입력 요청의 시간이 서로 중첩되거나 시작 시간이 끝나는 시간 보다 늦을 때 예외 처리
+        공연 스케줄 입력 요청의 시간이 서로 중첩되거나 정상적인 공연 시간이 아닐 때 예외 처리
         (스케줄 입력 요청을 시작 시간을 기준으로 정렬 후 확인)
          */
 
@@ -142,7 +142,8 @@ public class PerformanceService {
     private void checkCorrectPerfTime(PerformanceTimeRequest timeRequest) {
         /*
         정상적인 공연 시간 체크
-        (시작 시간이 끝나는 시간 보다 늦을 경우 예외처리)
+        - 시작 시간이 끝나는 시간 보다 늦을 경우 예외처리
+        - 공연 시간이 24시간 이상일 경우 예외처리
          */
 
         long startTime = Long.parseLong(timeRequest.getStartTime());
@@ -151,5 +152,10 @@ public class PerformanceService {
         if (startTime >= endTime) {
             throw new PerformanceTimeConflictException("공연 스케줄 시간을 잘못 입력하였습니다.");
         }
+
+        if(endTime - startTime > 24_00_00) {
+            throw new PerformanceTimeConflictException("공연 시간은 24시간을 초과할 수 없습니다.");
+        }
+
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -6,6 +6,7 @@ import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,6 +14,7 @@ public class PerformanceService {
 
     private final PerformanceMapper performanceMapper;
 
+    @Transactional
     public void insertPerformance(PerformanceRequest performanceRequest) {
         checkPerformanceExists(performanceRequest.getTitle(), performanceRequest.getShowType());
 

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -2,13 +2,17 @@ package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.performance.PerformanceAlreadyExistsException;
 import com.show.showticketingservice.mapper.PerformanceMapper;
+import com.show.showticketingservice.mapper.PerformanceTimeMapper;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
+import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +22,8 @@ public class PerformanceService {
     private String fileUploadPath;
 
     private final PerformanceMapper performanceMapper;
+
+    private final PerformanceTimeMapper performanceTimeMapper;
 
     private final FileService fileService;
 
@@ -39,7 +45,7 @@ public class PerformanceService {
 
         String imagePath = performanceMapper.getImagePath(performanceId);
 
-        if(imagePath != null) {
+        if (imagePath != null) {
             fileService.deleteFile(imagePath);
         }
 
@@ -47,4 +53,10 @@ public class PerformanceService {
         performanceMapper.updatePerfImagePath(performanceId, imagePath);
     }
 
+    public void insertPerformanceTimes(List<PerformanceTimeRequest> performanceTimeRequests, int performanceId) {
+
+        // 시간이 겹치는 지 확인 필요
+
+        performanceTimeMapper.insertPerformanceTimes(performanceTimeRequests, performanceId);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -71,7 +71,7 @@ public class PerformanceService {
         3. 검색된 스케줄이 입력하려는 스케줄의 시간과 중첩된다면 예외처리
          */
 
-        List<PerformanceTimeRequest> perfTimesFromDB = performanceTimeMapper.getPerfTimes(performanceId);
+        List<PerformanceTimeRequest> perfTimesFromDB = performanceTimeMapper.getPerfTimes(performanceId, performanceTimeRequests);
 
         if (perfTimesFromDB.size() == 0)
             return;

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -48,7 +48,7 @@ public class PerformanceService {
             fileService.deleteFile(imagePath);
         }
 
-        imagePath = fileService.registerImage(image);
+        imagePath = fileService.saveFile(image);
         performanceMapper.updatePerfImagePath(performanceId, imagePath);
     }
 

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -34,7 +34,13 @@ public class PerformanceService {
     }
 
     public void updatePosterImage(int performanceId, MultipartFile image) {
-        String imagePath = fileService.registerPosterImage(image);
+        String imagePath = performanceMapper.getImagePath(performanceId);
+
+        if(imagePath != null) {
+            fileService.deleteFile(imagePath);
+        }
+
+        imagePath = fileService.registerPosterImage(image);
         performanceMapper.updatePerfImagePath(performanceId, imagePath);
     }
 

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -5,25 +5,37 @@ import com.show.showticketingservice.mapper.PerformanceMapper;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
 public class PerformanceService {
 
+    @Value("${spring.servlet.multipart.location}")
+    private String fileUploadPath;
+
     private final PerformanceMapper performanceMapper;
+
+    private final FileService fileService;
 
     @Transactional
     public void insertPerformance(PerformanceRequest performanceRequest) {
         checkPerformanceExists(performanceRequest.getTitle(), performanceRequest.getShowType());
-
         performanceMapper.insertPerformance(performanceRequest);
     }
 
     public void checkPerformanceExists(String title, ShowType showType) {
-        if(performanceMapper.isPerformanceExists(title, showType)) {
+        if (performanceMapper.isPerformanceExists(title, showType)) {
             throw new PerformanceAlreadyExistsException();
         }
     }
+
+    public void updatePosterImage(int performanceId, MultipartFile image) {
+        String imagePath = fileService.registerPosterImage(image);
+        performanceMapper.updatePerfImagePath(performanceId, imagePath);
+    }
+
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.performance.PerformanceAlreadyExistsException;
+import com.show.showticketingservice.exception.performance.PerformanceTimeConflictException;
 import com.show.showticketingservice.mapper.PerformanceMapper;
 import com.show.showticketingservice.mapper.PerformanceTimeMapper;
 import com.show.showticketingservice.model.enumerations.ShowType;
@@ -11,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -51,8 +54,102 @@ public class PerformanceService {
 
     public void insertPerformanceTimes(List<PerformanceTimeRequest> performanceTimeRequests, int performanceId) {
 
-        // 시간이 겹치는 지 확인 필요
+        checkPerfTimeRequestConflict(performanceTimeRequests);
+
+        checkPerfTimeWithDB(performanceTimeRequests, performanceId);
 
         performanceTimeMapper.insertPerformanceTimes(performanceTimeRequests, performanceId);
+    }
+
+    private void checkPerfTimeWithDB(List<PerformanceTimeRequest> performanceTimeRequests, int performanceId) {
+        /*
+        입력하려는 공연 스케줄을 기존 DB에 저장되어 있는 스케줄과 비교
+
+        Logic:
+        1. DB의 스케줄을 가져와 startTime 기준으로 정렬 (perfTimesFromDB)
+        2. 정렬된 perfTimesFromDB를 endTime 기준으로 '이분탐색' 하여 입력하려는 스케줄의 시작 시간 보다 큰 스케줄 중 가장 작은 값을 검색
+        3. 검색된 스케줄이 입력하려는 스케줄의 시간과 중첩된다면 예외처리
+         */
+
+        List<PerformanceTimeRequest> perfTimesFromDB = performanceTimeMapper.getPerfTimes(performanceId);
+
+        if (perfTimesFromDB.size() == 0)
+            return;
+
+        Collections.sort(perfTimesFromDB, Comparator.comparing(PerformanceTimeRequest::getStartTime));
+
+        int timeRequestsSize = performanceTimeRequests.size();
+
+        for (int idx = 0; idx < timeRequestsSize; idx++) {
+
+            PerformanceTimeRequest timeRequest = performanceTimeRequests.get(idx);
+
+            long startTime = Long.parseLong(timeRequest.getStartTime());
+            long endTime = Long.parseLong(timeRequest.getEndTime());
+
+            int first = 0;
+            int last = perfTimesFromDB.size() - 1;
+
+            while (first < last) {
+                int mid = (first + last) / 2;
+
+                if (Long.parseLong(perfTimesFromDB.get(mid).getEndTime()) <= startTime)
+                    first = mid + 1;
+                else
+                    last = mid;
+            }
+
+            PerformanceTimeRequest refTimeRequest = perfTimesFromDB.get(first);
+
+            long refStartTime = Long.parseLong(refTimeRequest.getStartTime());
+            long refEndTime = Long.parseLong(refTimeRequest.getEndTime());
+
+            if (startTime < refEndTime && refStartTime < endTime) {
+                throw new PerformanceTimeConflictException("입력한 공연 스케줄 시간이 기존의 스케줄과 중첩 되었습니다.");
+            }
+
+        }
+    }
+
+    private void checkPerfTimeRequestConflict(List<PerformanceTimeRequest> performanceTimeRequests) {
+        /*
+        공연 스케줄 입력 요청의 시간이 서로 중첩되거나 시작 시간이 끝나는 시간 보다 늦을 때 예외 처리
+        (스케줄 입력 요청을 시작 시간을 기준으로 정렬 후 확인)
+         */
+
+        int size = performanceTimeRequests.size();
+
+        Collections.sort(performanceTimeRequests, Comparator.comparing(PerformanceTimeRequest::getStartTime));
+
+        PerformanceTimeRequest perfTime;
+
+        long preEndTime = 0;
+
+        for (int idx = 0; idx < size; idx++) {
+
+            perfTime = performanceTimeRequests.get(idx);
+
+            checkCorrectPerfTime(perfTime);
+
+            if (idx > 0 && preEndTime >= Long.parseLong(perfTime.getStartTime())) {
+                throw new PerformanceTimeConflictException("입력한 공연 스케줄 시간이 중첩 되었습니다.");
+            }
+
+            preEndTime = Long.parseLong(perfTime.getEndTime());
+        }
+    }
+
+    private void checkCorrectPerfTime(PerformanceTimeRequest timeRequest) {
+        /*
+        정상적인 공연 시간 체크
+        (시작 시간이 끝나는 시간 보다 늦을 경우 예외처리)
+         */
+
+        long startTime = Long.parseLong(timeRequest.getStartTime());
+        long endTime = Long.parseLong(timeRequest.getEndTime());
+
+        if (startTime >= endTime) {
+            throw new PerformanceTimeConflictException("공연 스케줄 시간을 잘못 입력하였습니다.");
+        }
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -1,0 +1,27 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.exception.performance.PerformanceAlreadyExistsException;
+import com.show.showticketingservice.mapper.PerformanceMapper;
+import com.show.showticketingservice.model.enumerations.ShowType;
+import com.show.showticketingservice.model.performance.PerformanceRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceService {
+
+    private final PerformanceMapper performanceMapper;
+
+    public void insertPerformance(PerformanceRequest performanceRequest) {
+        checkPerformanceExists(performanceRequest.getTitle(), performanceRequest.getShowType());
+
+        performanceMapper.insertPerformance(performanceRequest);
+    }
+
+    public void checkPerformanceExists(String title, ShowType showType) {
+        if(performanceMapper.isPerformanceExists(title, showType)) {
+            throw new PerformanceAlreadyExistsException();
+        }
+    }
+}

--- a/src/main/java/com/show/showticketingservice/tool/advice/FileExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/FileExceptionAdvice.java
@@ -1,0 +1,23 @@
+package com.show.showticketingservice.tool.advice;
+
+import com.show.showticketingservice.exception.file.InvalidFileTypeException;
+import com.show.showticketingservice.model.responses.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@Slf4j
+@RestControllerAdvice
+public class FileExceptionAdvice {
+
+    @ExceptionHandler(InvalidFileTypeException.class)
+    public ResponseEntity<ExceptionResponse> invalidFileTypeException(final InvalidFileTypeException e, WebRequest request) {
+        log.error("image file storing failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/tool/advice/FileExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/FileExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.show.showticketingservice.tool.advice;
 import com.show.showticketingservice.exception.file.InvalidFileTypeException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,7 +16,14 @@ public class FileExceptionAdvice {
 
     @ExceptionHandler(InvalidFileTypeException.class)
     public ResponseEntity<ExceptionResponse> invalidFileTypeException(final InvalidFileTypeException e, WebRequest request) {
-        log.error("image file storing failed", e);
+        log.error("Image file storing failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SizeLimitExceededException.class)
+    public ResponseEntity<ExceptionResponse> sizeLimitExceededException(final SizeLimitExceededException e, WebRequest request) {
+        log.error("Image file storing failed - The file size exceeded the allowed size(10MB)", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/show/showticketingservice/tool/advice/PerformanceExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/PerformanceExceptionAdvice.java
@@ -1,0 +1,23 @@
+package com.show.showticketingservice.tool.advice;
+
+import com.show.showticketingservice.exception.performance.PerformanceAlreadyExistsException;
+import com.show.showticketingservice.model.responses.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@Slf4j
+@RestControllerAdvice
+public class PerformanceExceptionAdvice {
+
+    @ExceptionHandler(PerformanceAlreadyExistsException.class)
+    public ResponseEntity<ExceptionResponse> performanceAlreadyExistsException(final PerformanceAlreadyExistsException e, WebRequest request) {
+        log.error("performance registration failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/tool/advice/PerformanceExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/PerformanceExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.tool.advice;
 
 import com.show.showticketingservice.exception.performance.PerformanceAlreadyExistsException;
+import com.show.showticketingservice.exception.performance.PerformanceTimeConflictException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,13 @@ public class PerformanceExceptionAdvice {
     @ExceptionHandler(PerformanceAlreadyExistsException.class)
     public ResponseEntity<ExceptionResponse> performanceAlreadyExistsException(final PerformanceAlreadyExistsException e, WebRequest request) {
         log.error("performance registration failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(PerformanceTimeConflictException.class)
+    public ResponseEntity<ExceptionResponse> performanceTimeConflictException(final PerformanceTimeConflictException e, WebRequest request) {
+        log.error("performance schedule registration failed", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
+++ b/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
@@ -23,7 +23,6 @@ public class FileUtil {
     }
 
     public void pathCheck(String fileUploadPath) {
-//        File path = new File(fileUploadPath);
 
         Path dir = Paths.get(fileUploadPath).toAbsolutePath().normalize();
 

--- a/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
+++ b/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
@@ -1,0 +1,36 @@
+package com.show.showticketingservice.tool.util;
+
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Component
+public class FileUtil {
+
+    public String renameFile(String originName) {
+
+        UUID uuid = UUID.randomUUID();
+
+        StringBuilder newName = new StringBuilder()
+                .append(uuid.toString())
+                .append("_")
+                .append(originName);
+
+        return newName.toString();
+    }
+
+    public void pathCheck(String fileUploadPath) {
+//        File path = new File(fileUploadPath);
+
+        Path dir = Paths.get(fileUploadPath).toAbsolutePath().normalize();
+
+        File path = new File(dir.toString());
+
+        if (!path.exists()) {
+            path.mkdirs();
+        }
+    }
+}

--- a/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
+++ b/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
@@ -1,16 +1,13 @@
 package com.show.showticketingservice.tool.util;
 
-import org.springframework.stereotype.Component;
-
 import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.UUID;
 
-@Component
 public class FileUtil {
 
-    public String renameFile(String originName) {
+    public static String renameFile(String originName) {
 
         UUID uuid = UUID.randomUUID();
 
@@ -22,7 +19,7 @@ public class FileUtil {
         return newName.toString();
     }
 
-    public void pathCheck(String fileUploadPath) {
+    public static void pathCheck(String fileUploadPath) {
 
         Path dir = Paths.get(fileUploadPath).toAbsolutePath().normalize();
 
@@ -33,7 +30,7 @@ public class FileUtil {
         }
     }
 
-    public boolean isImageFile(String contentType) {
+    public static boolean isImageFile(String contentType) {
         return contentType.contains("image/jpeg") || contentType.contains("image/png") || contentType.contains("image/gif");
     }
 }

--- a/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
+++ b/src/main/java/com/show/showticketingservice/tool/util/FileUtil.java
@@ -32,4 +32,8 @@ public class FileUtil {
             path.mkdirs();
         }
     }
+
+    public boolean isImageFile(String contentType) {
+        return contentType.contains("image/jpeg") || contentType.contains("image/png") || contentType.contains("image/gif");
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,9 @@ spring.redis.cache.port=6380
 
 #log4j2
 logging.config=src/main/resources/log/Log4j2.xml
+
+# fileUpload
+    spring.servlet.multipart.enabled=true
+    spring.servlet.multipart.location=files/performanceImages
+    spring.servlet.multipart.max-file-size=128KB
+    spring.servlet.multipart.max-request-size=128KB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,7 +21,7 @@ spring.redis.cache.port=6380
 logging.config=src/main/resources/log/Log4j2.xml
 
 # fileUpload
-    spring.servlet.multipart.enabled=true
-    spring.servlet.multipart.location=files/performanceImages
-    spring.servlet.multipart.max-file-size=128KB
-    spring.servlet.multipart.max-request-size=128KB
+spring.servlet.multipart.enabled=true
+spring.servlet.multipart.location=files/performanceImages
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -21,5 +21,11 @@
         SET imageFilePath = #{filePath}
         WHERE id = #{performanceId}
     </update>
+    
+    <select id="getImagePath" parameterType="int" resultType="String">
+        SELECT imageFilePath
+        FROM performance
+        WHERE id = #{performanceId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -4,8 +4,8 @@
 <mapper namespace="com.show.showticketingservice.mapper.PerformanceMapper">
 
     <insert id="insertPerformance" parameterType="com.show.showticketingservice.model.performance.PerformanceRequest">
-        INSERT INTO performance(title, imageFilePath, detail, ageLimit, showType, venueId, hallId)
-        VALUES(#{title}, #{imageFilePath}, #{detail}, #{ageLimit}, #{showType}, #{venueId}, #{hallId})
+        INSERT INTO performance(title, detail, ageLimit, showType, venueId, hallId)
+        VALUES(#{title}, #{detail}, #{ageLimit}, #{showType}, #{venueId}, #{hallId})
     </insert>
 
     <select id="isPerformanceExists" parameterType="map" resultType="boolean">
@@ -15,5 +15,11 @@
         WHERE title = #{title} AND showType = #{showType}
         )
     </select>
+
+    <update id="updatePerfImagePath" parameterType="map">
+        UPDATE performance
+        SET imageFilePath = #{filePath}
+        WHERE id = #{performanceId}
+    </update>
 
 </mapper>

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.show.showticketingservice.mapper.PerformanceMapper">
+
+    <insert id="insertPerformance" parameterType="com.show.showticketingservice.model.performance.PerformanceRequest">
+        INSERT INTO performance(title, posterId, detail, ageLimit, showType, venueId, hallId)
+        VALUES(#{title}, #{posterId}, #{detail}, #{ageLimit}, #{showType}, #{venueId}, #{hallId})
+    </insert>
+
+    <select id="isPerformanceExists" parameterType="map" resultType="boolean">
+        SELECT EXISTS
+        (
+        SELECT * FROM performance
+        WHERE title = #{title} AND showType = #{showType}
+        )
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -4,8 +4,8 @@
 <mapper namespace="com.show.showticketingservice.mapper.PerformanceMapper">
 
     <insert id="insertPerformance" parameterType="com.show.showticketingservice.model.performance.PerformanceRequest">
-        INSERT INTO performance(title, posterId, detail, ageLimit, showType, venueId, hallId)
-        VALUES(#{title}, #{posterId}, #{detail}, #{ageLimit}, #{showType}, #{venueId}, #{hallId})
+        INSERT INTO performance(title, imageFilePath, detail, ageLimit, showType, venueId, hallId)
+        VALUES(#{title}, #{imageFilePath}, #{detail}, #{ageLimit}, #{showType}, #{venueId}, #{hallId})
     </insert>
 
     <select id="isPerformanceExists" parameterType="map" resultType="boolean">

--- a/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
@@ -4,10 +4,15 @@
 <mapper namespace="com.show.showticketingservice.mapper.PerformanceTimeMapper">
 
     <insert id="insertPerformanceTimes" parameterType="map">
-        INSERT INTO performanceTime(performanceId, startTime, endTime)
+        INSERT INTO performanceTime(performanceId, hallId, startTime, endTime)
         VALUES
         <foreach collection="performanceTimeRequests" item="performanceTimeRequest" separator=",">
-            (#{performanceId}, #{performanceTimeRequest.startTime}, #{performanceTimeRequest.endTime})
+            (
+            #{performanceId},
+            (SELECT hallId FROM performance WHERE id = #{performanceId}),
+            #{performanceTimeRequest.startTime},
+            #{performanceTimeRequest.endTime}
+            )
         </foreach>
     </insert>
 

--- a/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
@@ -16,10 +16,20 @@
         </foreach>
     </insert>
 
-    <select id="getPerfTimes" parameterType="int" resultType="com.show.showticketingservice.model.performance.PerformanceTimeRequest">
+    <select id="getPerfTimes" parameterType="map"
+            resultType="com.show.showticketingservice.model.performance.PerformanceTimeRequest">
         SELECT date_format(startTime, '%Y%m%d%H%i%S'), date_format(endTime, '%Y%m%d%H%i%S')
         FROM performanceTime
-        WHERE performanceId = #{performanceId}
+        WHERE hallId = (SELECT hallId FROM performance WHERE id = #{performanceId}) AND
+        <foreach collection="performanceTimeRequests" item="performanceTimeRequest" open="(" close=")" separator="OR">
+            (
+            DATE(startTime)
+            BETWEEN
+            DATE(#{performanceTimeRequest.startTime}) - 1
+            AND
+            DATE(#{performanceTimeRequest.startTime}) + 1
+            )
+        </foreach>
     </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.show.showticketingservice.mapper.PerformanceTimeMapper">
+
+    <insert id="insertPerformanceTimes" parameterType="map">
+        INSERT INTO performanceTime(performanceId, startTime, endTime)
+        VALUES
+        <foreach collection="performanceTimeRequests" item="performanceTimeRequest" separator=",">
+            (#{performanceId}, #{performanceTimeRequest.startTime}, #{performanceTimeRequest.endTime})
+        </foreach>
+    </insert>
+
+</mapper>

--- a/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
@@ -11,4 +11,10 @@
         </foreach>
     </insert>
 
+    <select id="getPerfTimes" parameterType="int" resultType="com.show.showticketingservice.model.performance.PerformanceTimeRequest">
+        SELECT date_format(startTime, '%Y%m%d%H%i%S'), date_format(endTime, '%Y%m%d%H%i%S')
+        FROM performanceTime
+        WHERE performanceId = #{performanceId}
+    </select>
+
 </mapper>


### PR DESCRIPTION
## 개요

*[관리자 권한]*

1. **공연 정보 등록**
    - 공연 정보: 
        - title(공연명), imageFilePath(공연이미지 파일 위치), detail(상세설명), ageLimit(관람가능연령), showType(공연타입), venueId(공연장ID), hallId(공연홀ID)
        - 최초 공연 정보 등록 시 이미지 파일은 Null 값으로 등록(공연 등록 이후 이미지 등록 가능)
        > - 공연 타입(ShowType): 뮤지컬, 연극, 콘서트 
    - *공연장ID, 공연홀ID, 공연타입은 UI에서 선택하여 유효한 값 만을 넣는다고 가정*

2. **포스터 이미지 등록**
    - 기존에 존재하는 공연에 대하여 포스터 이미지 등록
    - *공연ID는 UI에서 선택하여 유효한 값 만을 넣는다고 가정*

3. **공연 스케줄 등록**
    - 기존에 존재하는 공연에 대하여 스케줄 등록
    - 하나의 공연에 여러 개의 스케줄 등록이 가능
    - 스케줄에는 공연 시작 시간과 끝나는 시간을 입력
    - 공연 시간은 최대 24시간으로 제한
    - *공연ID는 UI에서 선택하여 유효한 값 만을 넣는다고 가정*

4. **공연 스케줄 등록 시 시간 중첩 방지**
    - 같은 공연에 여러 스케줄 입력 중 발생 가능한 시간 중첩 방지
    - 문제 상황: 
        1. 끝나는 시간이 시작 시간 보다 빠른 경우
        2. 새로 등록하는 스케줄 간 시간이 중첩되는 경우
        3. 기존 DB에 등록된 스케줄과 시간이 중첩되는 경우


## Progress
- [x] 공연 정보 등록 기능
- [x] 포스터 이미지 등록 기능
- [x] 공연 스케줄 입력 기능
- [x] 같은 홀의 공연 등록 시 스케줄 중복 방지
- [x] 테스트


## Detail
1. **공연 정보 등록 기능**
    - Performance(공연) 관련 Controller, Service, Mapper 생성
        - `insertPerformance `메소드에서 공연 등록 로직 수행
    - `PerformanceRequest `객체로 공연 정보 받아옴
    - 공연 등록 전 공연명과 공연유형이 중복되었으면 `PerformanceAlreadyExistsException `에러
    - 공연 유형은 `ShowType `Enum 및 `TypeHandler` 로 처리

2. **포스터 이미지 등록 기능**
    - **MultipartFile**을 이용하여 파일 업로드 기능 구현
    - PUT 메소드 (공연 정보의 이미지 정보 업데이트 API)
        - 공연 등록 시 Request Body에 MultipartFile과 JSON 형식의 공연 정보를 함께 보낼 수 없으므로 기존 공연 정보 등록 API와 분리하여 구현
    - 이미지 저장 시 기존에 존재하는 파일이 있다면 삭제 후 저장되고 DB에선 새로운 파일의 저장경로로 속성을 update
    - 이미지는 프로젝트 파일의 files/performanceImages 폴더(상대경로)에 저장
    - FileService, FileUtil 클래스를 구현하여 파일 관련 기능 로직을 PerformanceService에서 분리
    - 관련 예외 상황 처리:
        - 지정된 파일 형식만 허용(이미지 파일: jpeg, png, gif)
        - 최대 파일 허용 크기: 10MB

3. **공연 스케줄 등록 기능**
    - **PerformanceTimeRequest** 객체로 공연 시작, 끝 시간 전달 받음
    - 공연 스케줄은 하나 이상이므로 PerformanceTimeRequest는 List로 받음
    - 이후 스케줄 시간 관리의 효율성을 위해 time format은 [Year,4][Month,2][Date,2][Hour,2][Minute,2][Second,2] 형식으로 총 14자리의 숫자로만 구성
    - DB에 저장되는 스케줄 시간은 **DATE_TIME** 형식으로 저장

4. **공연 스케줄 시간 중첩 방지 기능**
    - PerformanceService에서 스케줄 시간이 정상인지 또는 시간이 중첩되지 않는지 체크
    - 스케줄이 정상이 아니거나 중첩된다면 **PerformanceTimeConflictException** 예외처리
    - 구현:    
        **1. 입력된 스케줄 간의 중첩 체크(checkPerfTimeRequestConflict 메소드)**
            - performanceTimeRequest 리스트를 startTime을 기준으로 정렬
            - startTime과 endTime이 정상적인지 확인(checkCorrectPerfTime)
            - Linear 하게 스케줄이 중첩되지 않는 지 체크
        **2. DB에 저장되어 있는 스케줄과의 중첩 체크(checkPerfTimeWithDB 메소드)**
            - 기존에 존재하는 스케줄을 List로 가져와 startTime을 기준으로 정렬
            `- DB의 스케줄을 가져올 때 같은 홀의 스케줄 중 날짜 범위를 조정하여 체크 알고리즘의 효율 향상`
            `- 공연 시간이 이틀에 걸쳐 진행 될 수 있으므로 입력하려는 스케줄의 시작 시간을 기준으로 앞, 뒤 날짜 모두 SELECT`
            - 정렬된 스케줄을 endTime 기준으로 **이분탐색** 하여 입력하려는 스케줄의 startTime 보다 큰 스케줄 중 가장 작은 스케줄 검색
            - 검색된 스케줄이 입력하려는 스케줄의 시간과 중첩되는지 확인

5. **TEST**
    - 공연 id를 가져오는 것에 한계가 있어 로컬에서 **Postman**으로 테스트 진행
    - 정상적인 요청에 대한 기능은 모두 정상 동작 & 문제 상황에 대한 테스트 수행 및 해결
    - 문제 상황에서의 테스트:
        - **공연 이미지 등록**
            - 파일 크기가 허용 값 보다 초과되는 경우
            - 파일이 이미지가 아닌 경우
        - **공연 스케줄 등록**
            - 스케줄 시간이 정상이 아닌 경우(ex. 끝 시간이 시작 시간보다 빠름)
            - 스케줄이 서로 중첩되는 경우
        - **etc**
            - 관리자 권한이 없는 경우