### PR TITLE
[#35] 공연 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -3,6 +3,7 @@ package com.show.showticketingservice.controller;
 import com.show.showticketingservice.model.enumerations.AccessRoles;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
 import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
+import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import com.show.showticketingservice.service.PerformanceService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +36,12 @@ public class PerformanceController {
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
     public void insertPerfTime(@RequestBody @Valid List<PerformanceTimeRequest> performanceTimeRequests, @PathVariable int performanceId) {
         performanceService.insertPerformanceTimes(performanceTimeRequests, performanceId);
+    }
+
+    @PutMapping("/{performanceId}")
+    @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
+    public void updatePerformanceInfo(@PathVariable int performanceId, @RequestBody @Valid PerformanceUpdateRequest perfUpdateRequest) {
+        performanceService.updatePerformanceInfo(performanceId, perfUpdateRequest);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/exception/performance/PerformanceNotExistsException.java
+++ b/src/main/java/com/show/showticketingservice/exception/performance/PerformanceNotExistsException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.performance;
+
+public class PerformanceNotExistsException extends RuntimeException {
+
+    public PerformanceNotExistsException() {
+        super("공연 정보가 존재 하지 않습니다.");
+    }
+}

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.mapper;
 
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
+import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
@@ -14,4 +15,10 @@ public interface PerformanceMapper {
     void updatePerfImagePath(int performanceId, String filePath);
 
     String getImagePath(int performanceId);
+
+    boolean isPerformanceIdExists(int performanceId);
+
+    boolean isPerfTitleDuplicated(int performanceId, String title, ShowType showType);
+
+    void updatePerformanceInfo(int performanceId, PerformanceUpdateRequest perfUpdateRequest);
 }

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceUpdateRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceUpdateRequest.java
@@ -1,0 +1,30 @@
+package com.show.showticketingservice.model.performance;
+
+import com.show.showticketingservice.model.enumerations.ShowType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.lang.Nullable;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+public class PerformanceUpdateRequest {
+
+    @NotBlank(message = "공연 제목을 입력하세요.")
+    @Length(max = 50, message = "제목은 50자 내로 입력하세요.")
+    private final String title;
+
+    @Nullable
+    @Length(max = 500, message = "공연 설명은 500자 내로 입력하세요.")
+    private final String detail;
+
+    @Nullable
+    private final int ageLimit;
+
+    @NotNull(message = "공연 타입을 입력하세요.")
+    private final ShowType showType;
+
+}

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -1,12 +1,14 @@
 package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.performance.PerformanceAlreadyExistsException;
+import com.show.showticketingservice.exception.performance.PerformanceNotExistsException;
 import com.show.showticketingservice.exception.performance.PerformanceTimeConflictException;
 import com.show.showticketingservice.mapper.PerformanceMapper;
 import com.show.showticketingservice.mapper.PerformanceTimeMapper;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
 import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
+import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -157,5 +159,27 @@ public class PerformanceService {
             throw new PerformanceTimeConflictException("공연 시간은 24시간을 초과할 수 없습니다.");
         }
 
+    }
+
+    @Transactional
+    public void updatePerformanceInfo(int performanceId, PerformanceUpdateRequest perfUpdateRequest) {
+
+        checkValidPerformanceId(performanceId);
+
+        checkPerfTitleDuplicated(performanceId, perfUpdateRequest.getTitle(), perfUpdateRequest.getShowType());
+
+        performanceMapper.updatePerformanceInfo(performanceId, perfUpdateRequest);
+    }
+
+    private void checkValidPerformanceId(int performanceId) {
+        if(!performanceMapper.isPerformanceIdExists(performanceId)) {
+            throw new PerformanceNotExistsException();
+        }
+    }
+
+    private void checkPerfTitleDuplicated(int performanceId, String title, ShowType showType) {
+        if (performanceMapper.isPerfTitleDuplicated(performanceId, title, showType)) {
+            throw new PerformanceAlreadyExistsException();
+        }
     }
 }

--- a/src/main/java/com/show/showticketingservice/tool/advice/PerformanceExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/PerformanceExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.tool.advice;
 
 import com.show.showticketingservice.exception.performance.PerformanceAlreadyExistsException;
+import com.show.showticketingservice.exception.performance.PerformanceNotExistsException;
 import com.show.showticketingservice.exception.performance.PerformanceTimeConflictException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,13 @@ public class PerformanceExceptionAdvice {
     @ExceptionHandler(PerformanceTimeConflictException.class)
     public ResponseEntity<ExceptionResponse> performanceTimeConflictException(final PerformanceTimeConflictException e, WebRequest request) {
         log.error("performance schedule registration failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(PerformanceNotExistsException.class)
+    public ResponseEntity<ExceptionResponse> performanceNotExistsException(final PerformanceNotExistsException e, WebRequest request) {
+        log.error("The performance information does not exist", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -21,11 +21,34 @@
         SET imageFilePath = #{filePath}
         WHERE id = #{performanceId}
     </update>
-    
+
     <select id="getImagePath" parameterType="int" resultType="String">
         SELECT imageFilePath
         FROM performance
         WHERE id = #{performanceId}
     </select>
+
+    <select id="isPerformanceIdExists" resultType="boolean">
+        SELECT EXISTS
+        (
+        SELECT * FROM performance
+        WHERE id = #{performanceId}
+        )
+    </select>
+
+    <select id="isPerfTitleDuplicated" parameterType="map" resultType="boolean">
+        SELECT EXISTS
+        (
+        SELECT * FROM performance
+        WHERE id != #{performanceId} AND title = #{title} AND showType = #{showType}
+        )
+    </select>
+
+    <update id="updatePerformanceInfo" parameterType="map">
+        UPDATE performance
+        SET title = #{perfUpdateRequest.title}, detail = #{perfUpdateRequest.detail},
+        ageLimit = #{perfUpdateRequest.ageLimit}, showType = #{perfUpdateRequest.showType}
+        WHERE id = #{performanceId}
+    </update>
 
 </mapper>


### PR DESCRIPTION
## 개요
- **기존에 등록된 공연에 대해 정보 수정 기능**
    - 수정 가능 항목: 공연명(title), 상세설명(detail), 연령제한(ageLimit), 공연타입(showType)
    - 수정 불가 항목: 공연장, 공연홀 
        > 다른 공연과의 충돌이 많을 것이라 예상하여 금지 조치. (변경을 원한다면 공연 삭제 후 새로 등록 필요) 
- 공연 정보의 변경 여부는 FE에서 체크 & 수정 요청
- *관리자 권한*


## Progress
- `PerformanceUpdateRequest` 객체로 수정 데이터 전달
- **공연 정보 수정 프로세스:**
    1. 수정하려는 공연의 id가 유효한 지 검사 (`checkValidPerformanceId()`)
    2. 공연명이 같은 공연타입 범위내에서 다른 공연과 중복되지 않는 지 검사 (`checkPerfTitleDuplicated()`)
    3. 공연 정보 수정
- *수정 로직에 트랜잭션 적용*