### PR TITLE
[#69] 공연 스케줄 삭제 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -44,4 +44,10 @@ public class PerformanceController {
         performanceService.updatePerformanceInfo(performanceId, perfUpdateRequest);
     }
 
+    @DeleteMapping("/{performanceId}/times")
+    @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
+    public void deletePerformanceTimes(@PathVariable int performanceId, @RequestBody List<Integer> timeIds) {
+        performanceService.deletePerformanceTimes(performanceId, timeIds);
+    }
+
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceTimeMapper.java
@@ -12,4 +12,5 @@ public interface PerformanceTimeMapper {
 
     List<PerformanceTimeRequest> getPerfTimes(int performanceId, List<PerformanceTimeRequest> performanceTimeRequests);
 
+    void deletePerformanceTimes(int performanceId, List<Integer> timeIds);
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -182,4 +182,9 @@ public class PerformanceService {
             throw new PerformanceAlreadyExistsException();
         }
     }
+
+    public void deletePerformanceTimes(int performanceId, List<Integer> timeIds) {
+        checkValidPerformanceId(performanceId);
+        performanceTimeMapper.deletePerformanceTimes(performanceId, timeIds);
+    }
 }

--- a/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
@@ -32,4 +32,13 @@
         </foreach>
     </select>
 
+    <delete id="deletePerformanceTimes" parameterType="map">
+        DELETE FROM performanceTime
+        WHERE performanceId = #{performanceId}
+        AND id IN
+        <foreach collection="timeIds" item="timeId" open="(" close=")" separator=",">
+            #{timeId}
+        </foreach>
+    </delete>
+
 </mapper>


### PR DESCRIPTION
## 개요
- 기존에 등록되어 있는 공연의 스케줄 삭제 기능
- 한 번에 여러 개의 스케줄 삭제 가능
- 공연 스케줄 하나하나의 시간은 수정이 불가능
    > 삭제 후 재 등록 필요
- *관리자 권한*

## Progress
- **PathVariable**에 **공연ID**, **RequestBody**에 삭제할 **스케줄의 ID List**를 넣어 스케줄 삭제 요청
- 유효한 공연 ID인지 확인 후 해당 스케줄 삭제
- 스케줄 ID는 UI에서 선택하여 유효한 값만을 전달 받는다고 전제