### PR TITLE
[#61] 공연 상세 정보 조회

### DIFF
--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -53,6 +53,7 @@ public class RedisCacheConfig {
 
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
         redisCacheConfigMap.put(CacheConstant.VENUE, redisCacheConfig.entryTtl(Duration.ofHours(2L)));
+        redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofDays(1L)));
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .withInitialCacheConfigurations(redisCacheConfigMap)

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -57,8 +57,8 @@ public class PerformanceController {
     }
 
     @GetMapping("/{performanceId}")
-    public PerformanceDetailInfoResponse getPerformance(@PathVariable int performanceId) {
-        return performanceService.getPerformance(performanceId);
+    public PerformanceDetailInfoResponse getPerformanceDetailInfo(@PathVariable int performanceId) {
+        return performanceService.getPerformanceDetailInfo(performanceId);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
 import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import com.show.showticketingservice.service.PerformanceService;
@@ -42,6 +43,11 @@ public class PerformanceController {
     @UserAuthenticationNecessary(role = AccessRoles.MANAGER)
     public void updatePerformanceInfo(@PathVariable int performanceId, @RequestBody @Valid PerformanceUpdateRequest perfUpdateRequest) {
         performanceService.updatePerformanceInfo(performanceId, perfUpdateRequest);
+    }
+
+    @GetMapping("/{performanceId}")
+    public PerformanceResponse getPerformance(@PathVariable int performanceId) {
+        return performanceService.getPerformance(performanceId);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -2,7 +2,7 @@ package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
-import com.show.showticketingservice.model.performance.PerformanceResponse;
+import com.show.showticketingservice.model.performance.PerformanceDetailInfoResponse;
 import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
 import com.show.showticketingservice.model.performance.SeatPriceRequest;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
@@ -57,7 +57,7 @@ public class PerformanceController {
     }
 
     @GetMapping("/{performanceId}")
-    public PerformanceResponse getPerformance(@PathVariable int performanceId) {
+    public PerformanceDetailInfoResponse getPerformance(@PathVariable int performanceId) {
         return performanceService.getPerformance(performanceId);
     }
 

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -23,5 +23,5 @@ public interface PerformanceMapper {
 
     void updatePerformanceInfo(int performanceId, PerformanceUpdateRequest perfUpdateRequest);
 
-    PerformanceDetailInfoResponse getPerformance(int performanceId);
+    PerformanceDetailInfoResponse getPerformanceDetailInfo(int performanceId);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.mapper;
 
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -21,4 +22,6 @@ public interface PerformanceMapper {
     boolean isPerfTitleDuplicated(int performanceId, String title, ShowType showType);
 
     void updatePerformanceInfo(int performanceId, PerformanceUpdateRequest perfUpdateRequest);
+
+    PerformanceResponse getPerformance(int performanceId);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -2,7 +2,7 @@ package com.show.showticketingservice.mapper;
 
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
-import com.show.showticketingservice.model.performance.PerformanceResponse;
+import com.show.showticketingservice.model.performance.PerformanceDetailInfoResponse;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -23,5 +23,5 @@ public interface PerformanceMapper {
 
     void updatePerformanceInfo(int performanceId, PerformanceUpdateRequest perfUpdateRequest);
 
-    PerformanceResponse getPerformance(int performanceId);
+    PerformanceDetailInfoResponse getPerformance(int performanceId);
 }

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceDetailInfoResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceDetailInfoResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class PerformanceResponse {
+public class PerformanceDetailInfoResponse {
 
     private String title;
 

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceDetailInfoResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceDetailInfoResponse.java
@@ -25,4 +25,6 @@ public class PerformanceDetailInfoResponse {
     private VenueResponse venueResponse;
 
     private List<SeatPriceResponse> seatPriceResponses;
+
+    private String hallName;
 }

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceResponse.java
@@ -23,4 +23,6 @@ public class PerformanceResponse {
     private List<PerformanceTimeResponse> performanceTimeResponses;
 
     private VenueResponse venueResponse;
+
+    private List<SeatPriceResponse> seatPriceResponses;
 }

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceResponse.java
@@ -1,0 +1,26 @@
+package com.show.showticketingservice.model.performance;
+
+import com.show.showticketingservice.model.enumerations.ShowType;
+import com.show.showticketingservice.model.venue.VenueResponse;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PerformanceResponse {
+
+    private String title;
+
+    private String detail;
+
+    private int ageLimit;
+
+    private ShowType showType;
+
+    private List<PerformanceTimeResponse> performanceTimeResponses;
+
+    private VenueResponse venueResponse;
+}

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceTimeResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceTimeResponse.java
@@ -1,0 +1,14 @@
+package com.show.showticketingservice.model.performance;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PerformanceTimeResponse {
+
+    private String startTime;
+
+    private String endTime;
+}

--- a/src/main/java/com/show/showticketingservice/model/performance/SeatPriceResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/SeatPriceResponse.java
@@ -1,0 +1,15 @@
+package com.show.showticketingservice.model.performance;
+
+import com.show.showticketingservice.model.enumerations.RatingType;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SeatPriceResponse {
+
+    private int price;
+
+    private RatingType ratingType;
+}

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -186,7 +186,7 @@ public class PerformanceService {
     }
 
     @Cacheable(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
-    public PerformanceDetailInfoResponse getPerformance(int performanceId) {
-        return performanceMapper.getPerformance(performanceId);
+    public PerformanceDetailInfoResponse getPerformanceDetailInfo(int performanceId) {
+        return performanceMapper.getPerformanceDetailInfo(performanceId);
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -7,9 +7,12 @@ import com.show.showticketingservice.mapper.PerformanceMapper;
 import com.show.showticketingservice.mapper.PerformanceTimeMapper;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
 import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
+import com.show.showticketingservice.tool.constants.CacheConstant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -181,5 +184,10 @@ public class PerformanceService {
         if (performanceMapper.isPerfTitleDuplicated(performanceId, title, showType)) {
             throw new PerformanceAlreadyExistsException();
         }
+    }
+
+    @Cacheable(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
+    public PerformanceResponse getPerformance(int performanceId) {
+        return performanceMapper.getPerformance(performanceId);
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -7,7 +7,7 @@ import com.show.showticketingservice.mapper.PerformanceMapper;
 import com.show.showticketingservice.mapper.PerformanceTimeMapper;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
-import com.show.showticketingservice.model.performance.PerformanceResponse;
+import com.show.showticketingservice.model.performance.PerformanceDetailInfoResponse;
 import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import com.show.showticketingservice.tool.constants.CacheConstant;
@@ -186,7 +186,7 @@ public class PerformanceService {
     }
 
     @Cacheable(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
-    public PerformanceResponse getPerformance(int performanceId) {
+    public PerformanceDetailInfoResponse getPerformance(int performanceId) {
         return performanceMapper.getPerformance(performanceId);
     }
 }

--- a/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
@@ -4,4 +4,5 @@ public class CacheConstant {
 
     public static final String VENUE = "venue";
 
+    public static final String PERFORMANCE = "performance";
 }

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -66,8 +66,10 @@
         <result column="detail" property="detail"/>
         <result column="ageLimit" property="ageLimit"/>
         <result column="showType" property="showType"/>
+        <result column="hallName" property="hallName"/>
         <association property="venueResponse" javaType="com.show.showticketingservice.model.venue.VenueResponse">
-            <result column="name" property="name"/>
+            <id column="venueId" property="id"/>
+            <result column="venueName" property="name"/>
             <result column="address" property="address"/>
             <result column="tel" property="tel"/>
             <result column="homepage" property="homepage"/>
@@ -78,22 +80,25 @@
 
     <select id="getPerformanceDetailInfo" resultMap="performanceDetailInfoResponse">
         SELECT
-            p.title,
-            p.detail,
-            p.ageLimit,
-            p.showType,
-            pt.startTime,
-            pt.endTime,
-            v.name,
-            v.address,
-            v.tel,
-            v.homepage,
-            s.ratingType,
-            s.price
+            p.title AS title,
+            p.detail AS detail,
+            p.ageLimit AS ageLimit,
+            p.showType AS showType,
+            pt.startTime AS startTime,
+            pt.endTime AS endTime,
+            v.id AS venueId,
+            v.name AS venueName,
+            v.address AS address,
+            v.tel AS tel,
+            v.homepage AS homepage,
+            s.ratingType AS ratingType,
+            s.price AS price,
+            vh.name AS hallName
         FROM performance p
         INNER JOIN performanceTime pt ON p.id = pt.performanceId
         INNER JOIN venue v ON p.venueId = v.id
         INNER JOIN seatPrice s ON p.id = s.performanceId
+        INNER JOIN venueHall vh ON p.hallId = vh.id
         WHERE p.id = #{performanceId}
     </select>
 

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -51,4 +51,41 @@
         WHERE id = #{performanceId}
     </update>
 
+    <resultMap id="performanceTimeResponse" type="com.show.showticketingservice.model.performance.PerformanceTimeResponse">
+        <result column="startTime" property="startTime"/>
+        <result column="endTime" property="endTime"/>
+    </resultMap>
+
+    <resultMap id="performanceResponse" type="com.show.showticketingservice.model.performance.PerformanceResponse">
+        <result column="title" property="title"/>
+        <result column="detail" property="detail"/>
+        <result column="ageLimit" property="ageLimit"/>
+        <result column="showType" property="showType"/>
+        <association property="venueResponse" javaType="com.show.showticketingservice.model.venue.VenueResponse">
+            <result column="name" property="name"/>
+            <result column="address" property="address"/>
+            <result column="tel" property="tel"/>
+            <result column="homepage" property="homepage"/>
+        </association>
+        <collection property="performanceTimeResponses" resultMap="performanceTimeResponse"/>
+    </resultMap>
+
+    <select id="getPerformance" resultMap="performanceResponse">
+        SELECT
+            p.title,
+            p.detail,
+            p.ageLimit,
+            p.showType,
+            pt.startTime,
+            pt.endTime,
+            v.name,
+            v.address,
+            v.tel,
+            v.homepage
+        FROM performance p
+        INNER JOIN performanceTime pt ON p.id = pt.performanceId
+        INNER JOIN venue v ON p.venueId = v.id
+        WHERE p.id = #{performanceId}
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -61,7 +61,7 @@
         <result column="ratingType" property="ratingType"/>
     </resultMap>
 
-    <resultMap id="performanceResponse" type="com.show.showticketingservice.model.performance.PerformanceResponse">
+    <resultMap id="performanceDetailInfoResponse" type="com.show.showticketingservice.model.performance.PerformanceDetailInfoResponse">
         <result column="title" property="title"/>
         <result column="detail" property="detail"/>
         <result column="ageLimit" property="ageLimit"/>
@@ -76,7 +76,7 @@
         <collection property="seatPriceResponses" resultMap="seatPriceResponse"/>
     </resultMap>
 
-    <select id="getPerformance" resultMap="performanceResponse">
+    <select id="getPerformance" resultMap="performanceDetailInfoResponse">
         SELECT
             p.title,
             p.detail,

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -76,7 +76,7 @@
         <collection property="seatPriceResponses" resultMap="seatPriceResponse"/>
     </resultMap>
 
-    <select id="getPerformance" resultMap="performanceDetailInfoResponse">
+    <select id="getPerformanceDetailInfo" resultMap="performanceDetailInfoResponse">
         SELECT
             p.title,
             p.detail,

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -56,6 +56,11 @@
         <result column="endTime" property="endTime"/>
     </resultMap>
 
+    <resultMap id="seatPriceResponse" type="com.show.showticketingservice.model.performance.SeatPriceResponse">
+        <result column="price" property="price"/>
+        <result column="ratingType" property="ratingType"/>
+    </resultMap>
+
     <resultMap id="performanceResponse" type="com.show.showticketingservice.model.performance.PerformanceResponse">
         <result column="title" property="title"/>
         <result column="detail" property="detail"/>
@@ -68,6 +73,7 @@
             <result column="homepage" property="homepage"/>
         </association>
         <collection property="performanceTimeResponses" resultMap="performanceTimeResponse"/>
+        <collection property="seatPriceResponses" resultMap="seatPriceResponse"/>
     </resultMap>
 
     <select id="getPerformance" resultMap="performanceResponse">
@@ -81,10 +87,13 @@
             v.name,
             v.address,
             v.tel,
-            v.homepage
+            v.homepage,
+            s.ratingType,
+            s.price
         FROM performance p
         INNER JOIN performanceTime pt ON p.id = pt.performanceId
         INNER JOIN venue v ON p.venueId = v.id
+        INNER JOIN seatPrice s ON p.id = s.performanceId
         WHERE p.id = #{performanceId}
     </select>
 


### PR DESCRIPTION
1. 공연 상세 정보를 조회하여 공연 정보, 공연 시간, 공연장 정보, 가격 정보, 이미지를 불러옴
2. cache
    * 공연 상세 정보는 많은 유저들이 요청할 수 있기 때문에 cache 적용
    * 변화가 잘 일어나지 않은 정보여서 cache 시간을 길게 잡으려 했지만 인기가 없는 공연일 경우 조회를 하지 않을 가능성이
      있어서 cache 시간을 하루 적용
3. mapper
    * 한 번에 공연 정보, 공연 시간, 공연장 정보를 불러오기 위해 join 사용
    * 공연 정보는 한 개의 공연장 정보를 불러오기 때문에 association 적용
    * 공연 정보, 가격 정보는 여러 개의 공연 시간을 불러오기 때문에 collection 적용
4. enum타입
    * ratingType의 좌석 등급은 1번: VIP   2번: S   3번: A석
    * showType의 공연 타입은 1번:MUSICAL  2번:THEATRICAL  3번:CONCERT
    