### PR TITLE
[#73] 찜(Pick) 기능 구현

### DIFF
--- a/etc/show_ticketing_service.sql
+++ b/etc/show_ticketing_service.sql
@@ -93,3 +93,13 @@ CREATE TABLE seat
     FOREIGN KEY (priceId)    REFERENCES seatPrice(id) ON DELETE CASCADE,
     FOREIGN KEY (hallId)     REFERENCES venueHall(id) ON DELETE CASCADE
 );
+
+CREATE TABLE pick
+(
+    `id`             INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
+    `userId`         INT UNSIGNED    NOT NULL,
+    `performanceId`  INT UNSIGNED    NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (userId)        REFERENCES user(id)         ON DELETE CASCADE,
+    FOREIGN KEY (performanceId) REFERENCES performance(id)  ON DELETE CASCADE
+);

--- a/src/main/java/com/show/showticketingservice/controller/PickController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PickController.java
@@ -1,0 +1,28 @@
+package com.show.showticketingservice.controller;
+
+import com.show.showticketingservice.model.enumerations.AccessRoles;
+import com.show.showticketingservice.model.pick.PickRequest;
+import com.show.showticketingservice.model.user.UserSession;
+import com.show.showticketingservice.service.PickService;
+import com.show.showticketingservice.tool.annotation.CurrentUser;
+import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/picks")
+public class PickController {
+
+    private final PickService pickService;
+
+    @PostMapping
+    @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
+        public void insertPick(@CurrentUser UserSession userSession, @RequestBody PickRequest pickRequest) {
+            pickService.insertPick(userSession.getUserId(), pickRequest.getPerformanceId());
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/controller/PickController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PickController.java
@@ -7,10 +7,7 @@ import com.show.showticketingservice.service.PickService;
 import com.show.showticketingservice.tool.annotation.CurrentUser;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,8 +18,13 @@ public class PickController {
 
     @PostMapping
     @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
-        public void insertPick(@CurrentUser UserSession userSession, @RequestBody PickRequest pickRequest) {
-            pickService.insertPick(userSession.getUserId(), pickRequest.getPerformanceId());
+    public void insertPick(@CurrentUser UserSession userSession, @RequestBody PickRequest pickRequest) {
+        pickService.insertPick(userSession.getUserId(), pickRequest.getPerformanceId());
     }
 
+    @DeleteMapping("/{performanceId}")
+    @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
+    public void deletePick(@CurrentUser UserSession userSession, @PathVariable int performanceId) {
+        pickService.deletePick(userSession.getUserId(), performanceId);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/exception/pick/PickAlreadyExistsException.java
+++ b/src/main/java/com/show/showticketingservice/exception/pick/PickAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.show.showticketingservice.exception.pick;
+
+public class PickAlreadyExistsException extends RuntimeException {
+
+    public PickAlreadyExistsException() {
+        super("이미 찜으로 등록된 공연입니다.");
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/mapper/PickMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PickMapper.java
@@ -9,4 +9,5 @@ public interface PickMapper {
 
     boolean isPickExists(int userNum, int performanceId);
 
+    void deletePick(int userNum, int performanceId);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PickMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PickMapper.java
@@ -1,0 +1,12 @@
+package com.show.showticketingservice.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface PickMapper {
+
+    void insertPick(int userId, int performanceId);
+
+    boolean isPickExists(int userNum, int performanceId);
+
+}

--- a/src/main/java/com/show/showticketingservice/mapper/UserMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/UserMapper.java
@@ -19,4 +19,7 @@ public interface UserMapper {
     void deleteUserByUserId(String userId);
 
     String getUserPasswordByUserId(String UserId);
+
+    int getUserNum(String userId);
+
 }

--- a/src/main/java/com/show/showticketingservice/mapper/UserMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/UserMapper.java
@@ -14,9 +14,9 @@ public interface UserMapper {
 
     UserResponse getUserByUserId(String userId);
 
-    void updateUserInfo(@Param("userId") String userId, @Param("updateRequest") UserUpdateRequest userUpdateRequest);
+    void updateUserInfo(@Param("id") int id, @Param("updateRequest") UserUpdateRequest userUpdateRequest);
 
-    void deleteUserByUserId(String userId);
+    void deleteUserById(int id);
 
-    String getUserPasswordByUserId(String UserId);
+    String getUserPasswordById(int id);
 }

--- a/src/main/java/com/show/showticketingservice/model/pick/PickRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/pick/PickRequest.java
@@ -1,0 +1,14 @@
+package com.show.showticketingservice.model.pick;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PickRequest {
+
+    private int performanceId;
+
+}

--- a/src/main/java/com/show/showticketingservice/model/user/UserSession.java
+++ b/src/main/java/com/show/showticketingservice/model/user/UserSession.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 @AllArgsConstructor
 public class UserSession implements Serializable {
 
-    private final String userId;
+    private final int userId;
 
     private final UserType userType;
 

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -228,7 +228,7 @@ public class PerformanceService {
         performanceMapper.updatePerformanceInfo(performanceId, perfUpdateRequest);
     }
 
-    private void checkValidPerformanceId(int performanceId) {
+    public void checkValidPerformanceId(int performanceId) {
         if(!performanceMapper.isPerformanceIdExists(performanceId)) {
             throw new PerformanceNotExistsException();
         }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -1,0 +1,35 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.exception.pick.PickAlreadyExistsException;
+import com.show.showticketingservice.mapper.PickMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PickService {
+
+    private final UserService userService;
+
+    private final PerformanceService performanceService;
+
+    private final PickMapper pickMapper;
+
+    public void insertPick(String userId, int performanceId) {
+
+        performanceService.checkValidPerformanceId(performanceId);
+
+        int userNum = userService.getUserNum(userId);
+
+        checkPickDuplicated(userNum, performanceId);
+
+        pickMapper.insertPick(userNum, performanceId);
+    }
+
+    private void checkPickDuplicated(int userNum, int performanceId) {
+        if (pickMapper.isPickExists(userNum, performanceId)) {
+            throw new PickAlreadyExistsException();
+        }
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -32,4 +32,10 @@ public class PickService {
         }
     }
 
+    public void deletePick(String userId, int performanceId) {
+
+        int userNum = userService.getUserNum(userId);
+
+        pickMapper.deletePick(userNum, performanceId);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
+++ b/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
@@ -28,7 +28,7 @@ public class SessionLoginService implements LoginService {
 
         UserResponse userResponse = userService.getUser(userLoginRequest.getUserId(), userLoginRequest.getPassword());
 
-        UserSession userSession = new UserSession(userResponse.getUserId(), userResponse.getUserType());
+        UserSession userSession = new UserSession(userResponse.getId(), userResponse.getUserType());
 
         httpSession.setAttribute(USER, userSession);
 

--- a/src/main/java/com/show/showticketingservice/service/UserService.java
+++ b/src/main/java/com/show/showticketingservice/service/UserService.java
@@ -69,4 +69,8 @@ public class UserService {
         String newEncryptedPassword = passwordEncryptor.encrypt(userUpdateRequest.getNewPassword());
         userMapper.updateUserInfo(userSession.getUserId(), userUpdateRequest.pwEncryptedUserUpdateRequest(newEncryptedPassword));
     }
+
+    public int getUserNum(String userId) {
+        return userMapper.getUserNum(userId);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/service/UserService.java
+++ b/src/main/java/com/show/showticketingservice/service/UserService.java
@@ -56,13 +56,13 @@ public class UserService {
 
     public void deleteUser(UserSession userSession, String passwordRequest) {
 
-        String hashPassword = userMapper.getUserPasswordByUserId(userSession.getUserId());
+        String hashPassword = userMapper.getUserPasswordById(userSession.getUserId());
 
         if(!isPasswordMatches(passwordRequest, hashPassword)) {
             throw new UserPasswordWrongException();
         }
 
-        userMapper.deleteUserByUserId(userSession.getUserId());
+        userMapper.deleteUserById(userSession.getUserId());
     }
 
     public void updateUserInfo(UserSession userSession, UserUpdateRequest userUpdateRequest) {

--- a/src/main/java/com/show/showticketingservice/tool/advice/PickExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/PickExceptionAdvice.java
@@ -1,0 +1,23 @@
+package com.show.showticketingservice.tool.advice;
+
+import com.show.showticketingservice.exception.pick.PickAlreadyExistsException;
+import com.show.showticketingservice.model.responses.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@Slf4j
+@RestControllerAdvice
+public class PickExceptionAdvice {
+
+    @ExceptionHandler(PickAlreadyExistsException.class)
+    public ResponseEntity<ExceptionResponse> pickAlreadyExistsException(final PickAlreadyExistsException e, WebRequest request) {
+        log.error("pick registration failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/resources/mybatis/mappers/PickMapper.xml
+++ b/src/main/resources/mybatis/mappers/PickMapper.xml
@@ -16,4 +16,9 @@
         )
     </select>
 
+    <delete id="deletePick" parameterType="map">
+        DELETE FROM pick
+        WHERE userId = #{userNum} AND performanceId = #{performanceId}
+    </delete>
+
 </mapper>

--- a/src/main/resources/mybatis/mappers/PickMapper.xml
+++ b/src/main/resources/mybatis/mappers/PickMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.show.showticketingservice.mapper.PickMapper">
+
+    <insert id="insertPick" parameterType="map">
+        INSERT INTO pick(userId, performanceId)
+        VALUES(#{userId}, #{performanceId})
+    </insert>
+
+    <select id="isPickExists" parameterType="map" resultType="boolean">
+        SELECT EXISTS
+        (
+        SELECT * FROM pick
+        WHERE userId = #{userNum} AND performanceId = #{performanceId}
+        )
+    </select>
+
+</mapper>

--- a/src/main/resources/mybatis/mappers/UserMapper.xml
+++ b/src/main/resources/mybatis/mappers/UserMapper.xml
@@ -3,7 +3,7 @@
 
 <mapper namespace="com.show.showticketingservice.mapper.UserMapper">
 
-    <insert id="insertUser" parameterType="com.show.showticketingservice.model.user.UserRequest">
+    <insert id="insertUser" parameterType="com.show.showticketingservice.model.user.UserRequest" keyProperty="id">
         INSERT INTO user(userId, password, name, phoneNum, email, address, userType)
         VALUES(#{userId}, #{password}, #{name}, #{phoneNum}, #{email}, #{address}, #{userType})
     </insert>
@@ -22,17 +22,17 @@
     <update id="updateUserInfo" parameterType="map" >
         UPDATE user
         SET password = #{updateRequest.newPassword}, phoneNum = #{updateRequest.newPhoneNum}, address = #{updateRequest.newAddress}
-        WHERE userId = #{userId}
+        WHERE id = #{id}
     </update>
 
-    <select id="getUserPasswordByUserId" parameterType="String" resultType="String" >
+    <select id="getUserPasswordById" parameterType="int" resultType="String" >
         SELECT password
         FROM user
-        WHERE userId = #{userId}
+        WHERE id = #{id}
     </select>
 
-    <delete id="deleteUserByUserId" parameterType="String">
-        DELETE FROM user WHERE userId = #{userId}
+    <delete id="deleteUserById" parameterType="int">
+        DELETE FROM user WHERE id = #{id}
     </delete>
 
 </mapper>

--- a/src/main/resources/mybatis/mappers/UserMapper.xml
+++ b/src/main/resources/mybatis/mappers/UserMapper.xml
@@ -35,4 +35,10 @@
         DELETE FROM user WHERE userId = #{userId}
     </delete>
 
+    <select id="getUserNum" resultType="int">
+        SELECT id
+        FROM user
+        WHERE userId = #{userId}
+    </select>
+
 </mapper>

--- a/src/test/java/com/show/showticketingservice/controller/MyPageControllerTest.java
+++ b/src/test/java/com/show/showticketingservice/controller/MyPageControllerTest.java
@@ -19,7 +19,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
-import static com.show.showticketingservice.tool.constants.UserConstant.USER;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -51,14 +50,9 @@ class MyPageControllerTest {
     public void init() {
         testUser = new UserRequest("testId1", "testPW1234#", "Test User", "010-1111-1111", "user1@example.com", "Seoul, South Korea", UserType.GENERAL);
 
-        userSession = new UserSession(testUser.getUserId(), testUser.getUserType());
-
         updateRequest = new UserUpdateRequest("!validPW123", "010-1234-5678", "Busan, South Korea");
 
         mvc = MockMvcBuilders.webAppContextSetup(context).build();
-
-        httpSession.setAttribute(USER, userSession);
-
     }
 
     private void insertUser(UserRequest userRequest) throws Exception {
@@ -79,6 +73,7 @@ class MyPageControllerTest {
 
         mvc.perform(post("/login")
                 .content(content)
+                .session(httpSession)
                 .contentType(MediaType.APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())

--- a/src/test/java/com/show/showticketingservice/controller/UserControllerTest.java
+++ b/src/test/java/com/show/showticketingservice/controller/UserControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,7 +45,7 @@ class UserControllerTest {
     public void init() {
         testUser = new UserRequest("testId1", "testPW1234#", "Test User", "010-1111-1111", "user1@example.com", "Seoul, South Korea", UserType.GENERAL);
         managerAccount = new UserRequest("managerTest1", "testPW1234#", "Test Manager", "010-1111-1111", "user1@example.com", "Seoul, South Korea", UserType.MANAGER);
-        userSession = new UserSession(testUser.getUserId(), testUser.getUserType());
+        userSession = new UserSession(1, testUser.getUserType());
 
         this.mvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
 

--- a/src/test/java/com/show/showticketingservice/controller/VenueControllerTest.java
+++ b/src/test/java/com/show/showticketingservice/controller/VenueControllerTest.java
@@ -78,7 +78,10 @@ class VenueControllerTest {
     }
 
     private void loginUser(UserRequest userRequest) throws Exception {
-        UserSession userSession = new UserSession(userRequest.getUserId(), userRequest.getUserType());
+
+        int tmpUserNum = 1;
+
+        UserSession userSession = new UserSession(tmpUserNum, userRequest.getUserType());
 
         httpSession.setAttribute(USER, userSession);
     }


### PR DESCRIPTION
- [x] 찜 하기 
- [x] 찜 삭제 (단일 목록)

## 개요:
1. **찜하기**
    - 기존에 존재하는 공연에 대해 찜 목록에 추가하는 기능
    - 찜 하기는 공연 상세 정보 조회 후 한번에 하나의 공연만 찜 가능
2. **찜 삭제 (단일 목록)**
    - 단일 공연 상세 페이지에서 찜 된 상태를 해지
    - 한번의 요청에 하나의 공연만 찜 삭제
    > 다중 목록 삭제는 '찜 목록 조회' 기능 구현 이후에 진행

*일반(GENERAL) 고객 기능*

<br>

## Progress
1. **찜 하기**
    - DB에 찜(pick) 테이블 생성
    - 찜 추가 기능 로직[**insertPick()**]:
        1. 현재 로그인 된 userSession과 찜 할 공연의 performanceId로 찜 추가요청
        2. **checkValidPerformanceId()** - performanceId가 유효한 지 확인 / PerformanceNotExistsException 예외
        3. **getUserNum()** - userSession에서 userId를 활용하여 userNum(user의 id) 획득
        4. **checkPickDuplicated()** - 중복된 찜 목록이 있는지 확인 / PickAlreadyExistsException 예외
        5. **insertPick()** - pick 테이블에 insert
2. **찜 삭제(단일 목록)**
    - PathVariable로 찜에서 삭제할 공연의 performanceId 전달
    - 현재 로그인 된 유저의 userId를 활용해 userNum(User.id) 획득
    - DB의 pick 테이블에서 userNum과 performanceId에 매칭되는 찜 데이터 삭제

<br>

## Test
> 테스트는 Postman을 통해 진행

1. **찜하기:**
    - 성공 case - *일반 회원으로 로그인 후 유효한 공연 id로 찜 추가*
    - 실패1 - *로그인 하지 않은 상태로 찜 추가 요청*
    - 실패2 - *관리자 회원으로 찜 추가 요청*
    - 실패3 - *등록되지 않은 공연 id로 찜 추가 요청*
    - 실패4 - *이미 찜 목록에 등록된 공연을 중복으로 찜 추가 요청*
2. **찜 삭제(단일)**
    - 성공 case - *일반 회원으로 로그인 후 찜 목록에 등록된 공연 id로 찜 삭제*
    - 실패1 - *로그인 하지 않은 상태로 찜 삭제 요청*
    - 실패2 - *관리자 회원으로 찜 삭제 요청*
    - 무시 - *찜 목록에 없는 공연 삭제(아무 일도 일어나지 않음)*