### PR TITLE
[#93] 공연 상세 정보 조회 기능 수정 및 기능 추가

### DIFF
--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -16,6 +16,7 @@ import com.show.showticketingservice.model.venueHall.VenueHallColumnSeat;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import com.show.showticketingservice.tool.constants.CacheConstant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,6 +55,7 @@ public class PerformanceService {
         }
     }
 
+    @CacheEvict(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
     public void updatePosterImage(int performanceId, MultipartFile image) {
 
         fileService.checkFileContentType(image);
@@ -69,6 +71,7 @@ public class PerformanceService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
     public void insertPerformanceTimes(List<PerformanceTimeRequest> performanceTimeRequests, int performanceId) {
 
         checkPerfTimeRequestConflict(performanceTimeRequests);
@@ -222,6 +225,7 @@ public class PerformanceService {
     }
 
     @Transactional
+    @CacheEvict(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
     public void updatePerformanceInfo(int performanceId, PerformanceUpdateRequest perfUpdateRequest) {
 
         checkValidPerformanceId(performanceId);
@@ -248,11 +252,13 @@ public class PerformanceService {
         return performanceMapper.getPerformanceDetailInfo(performanceId);
     }
 
+    @CacheEvict(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
     public void deletePerformanceTimes(int performanceId, List<Integer> timeIds) {
         checkValidPerformanceId(performanceId);
         performanceTimeMapper.deletePerformanceTimes(performanceId, timeIds);
     }
 
+    @CacheEvict(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
     public void deletePerformance(int performanceId) {
         checkValidPerformanceId(performanceId);
         performanceMapper.deletePerformance(performanceId);

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -249,6 +249,7 @@ public class PerformanceService {
 
     @Cacheable(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
     public PerformanceDetailInfoResponse getPerformanceDetailInfo(int performanceId) {
+        checkValidPerformanceId(performanceId);
         return performanceMapper.getPerformanceDetailInfo(performanceId);
     }
 
@@ -263,4 +264,5 @@ public class PerformanceService {
         checkValidPerformanceId(performanceId);
         performanceMapper.deletePerformance(performanceId);
     }
+
 }

--- a/src/main/java/com/show/showticketingservice/service/SeatPriceService.java
+++ b/src/main/java/com/show/showticketingservice/service/SeatPriceService.java
@@ -8,7 +8,9 @@ import com.show.showticketingservice.mapper.SeatPriceMapper;
 import com.show.showticketingservice.model.enumerations.RatingType;
 import com.show.showticketingservice.model.performance.SeatPriceRowNumData;
 import com.show.showticketingservice.model.performance.SeatPriceRequest;
+import com.show.showticketingservice.tool.constants.CacheConstant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.List;
@@ -78,6 +80,7 @@ public class SeatPriceService {
         });
     }
 
+    @CacheEvict(cacheNames = CacheConstant.PERFORMANCE, key = "#performanceId")
     public void insertSeatsPrice(List<SeatPriceRequest> seatPriceRequests, int performanceId) {
 
         checkSeatPriceAlreadyExistsException(performanceId);

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -102,9 +102,9 @@
             s.price AS price,
             vh.name AS hallName
         FROM performance p
-        INNER JOIN performanceTime pt ON p.id = pt.performanceId
+        LEFT OUTER JOIN performanceTime pt ON p.id = pt.performanceId
+        LEFT OUTER JOIN seatPrice s ON p.id = s.performanceId
         INNER JOIN venue v ON p.venueId = v.id
-        INNER JOIN seatPrice s ON p.id = s.performanceId
         INNER JOIN venueHall vh ON p.hallId = vh.id
         WHERE p.id = #{performanceId}
     </select>


### PR DESCRIPTION
### 기능 정의

1. 기존에 공연 시간, 가격이 추가되기 되기 전에 USER가 공연 상세 정보를 조회 시 공연 정보 전체가 null 값으로 나옴
공연 시간, 가격만 null 값으로 나오게 하기 위해 mapper에서 INNER JOIN => LEFT OUTER JOIN으로 수정
2. 공연 시간, 가격, 이미지가 추가되기 전에 USER가 공연 상세 정보 조회 시 이 데이터가 캐시에 저장됨
따라서 공연 시간, 가격을 추가 후에도 조회 시 캐시에 저장된 데이터가 전달되기 때문에 공연 시간, 가격 추가 시
캐시 데이터를 소멸 시켜주는 기능을 추가해줌
3. 공연 시간 삭제, 공연 수정, 삭제 시 캐시에 있는 공연 정보 데이터를 소멸 시켜주는 기능을 추가해줌
4. 존재하지 않는 공연 id로 조회 시 예외 처리

---
### 작업 리스트

- [x] 공연 상세 정보 mapper 기능 수정
- [x] 캐시 기능 추가
- [x] 추가하지 않는 공연 정보 조회 시 예외 처리