### PR TITLE
[#95] 공연 스케줄 중복 확인 버그 해결

### DIFF
--- a/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceTimeMapper.xml
@@ -18,7 +18,7 @@
 
     <select id="getPerfTimes" parameterType="map"
             resultType="com.show.showticketingservice.model.performance.PerformanceTimeRequest">
-        SELECT date_format(startTime, '%Y%m%d%H%i%S'), date_format(endTime, '%Y%m%d%H%i%S')
+        SELECT id, date_format(startTime, '%Y%m%d%H%i%S'), date_format(endTime, '%Y%m%d%H%i%S')
         FROM performanceTime
         WHERE hallId = (SELECT hallId FROM performance WHERE id = #{performanceId}) AND
         <foreach collection="performanceTimeRequests" item="performanceTimeRequest" open="(" close=")" separator="OR">


### PR DESCRIPTION
- **문제점:** 스케줄 등록 시 스케줄 중복 체크 단계에서 DB의 기존의 공연 스케줄을 `PerformanceTimeRequest `타입으로 가져오는 과정에 타입 변환 오류 발생
- **발생 원인:** 스케줄 입력 시 자동으로 좌석 정보 등록 구현 중 객체 구조의 변경으로 인한 충돌
- **해결:** `PerformanceTimeRequest `클래스에 추가된 `id` 값을 함께 반환 처리