### PR TITLE
[#84] 공연 리스트 조회

### DIFF
--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -54,7 +54,10 @@ public class RedisCacheConfig {
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
         redisCacheConfigMap.put(CacheConstant.VENUE, redisCacheConfig.entryTtl(Duration.ofHours(2L)));
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofDays(1L)));
-
+        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
+        redisCacheConfigMap.put(CacheConstant.MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
+        redisCacheConfigMap.put(CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
+        redisCacheConfigMap.put(CacheConstant.ALL_TYPE_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
         return RedisCacheManager.builder(redisConnectionFactory)
                 .withInitialCacheConfigurations(redisCacheConfigMap)
                 .build();

--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -54,9 +54,9 @@ public class RedisCacheConfig {
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
         redisCacheConfigMap.put(CacheConstant.VENUE, redisCacheConfig.entryTtl(Duration.ofHours(2L)));
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofDays(1L)));
-        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
-        redisCacheConfigMap.put(CacheConstant.MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
-        redisCacheConfigMap.put(CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
+        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(5L)));
+        redisCacheConfigMap.put(CacheConstant.MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(15L)));
+        redisCacheConfigMap.put(CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(20L)));
         redisCacheConfigMap.put(CacheConstant.ALL_TYPE_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
         return RedisCacheManager.builder(redisConnectionFactory)
                 .withInitialCacheConfigurations(redisCacheConfigMap)

--- a/src/main/java/com/show/showticketingservice/config/WebMvcConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/WebMvcConfig.java
@@ -1,9 +1,12 @@
 package com.show.showticketingservice.config;
 
+import com.show.showticketingservice.tool.converter.StringToShowTypeConverter;
 import com.show.showticketingservice.tool.interceptor.LoginCheckInterceptor;
 import com.show.showticketingservice.tool.resolver.CurrentUserArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistrar;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -17,6 +20,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
 
     private final CurrentUserArgumentResolver currentUserArgumentResolver;
 
+    private final StringToShowTypeConverter stringToShowTypeConverter;
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loginCheckInterceptor);
@@ -25,5 +30,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserArgumentResolver);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(stringToShowTypeConverter);
     }
 }

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.controller;
 
+import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.enumerations.AccessRoles;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.*;
@@ -62,6 +63,6 @@ public class PerformanceController {
     @GetMapping
     public List<PerformanceResponse> getPerformances(@RequestParam(value = "showType", required = false) ShowType showType,
                                                      @RequestParam(value = "lastPerfId", required = false) Integer lastPerfId) {
-        return performanceService.getPerformances(showType, lastPerfId);
+        return performanceService.getPerformances(showType, new PerformancePagingCriteria(lastPerfId));
     }
 }

--- a/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PerformanceController.java
@@ -1,15 +1,13 @@
 package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
-import com.show.showticketingservice.model.performance.PerformanceRequest;
-import com.show.showticketingservice.model.performance.PerformanceDetailInfoResponse;
-import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
-import com.show.showticketingservice.model.performance.SeatPriceRequest;
-import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
+import com.show.showticketingservice.model.enumerations.ShowType;
+import com.show.showticketingservice.model.performance.*;
 import com.show.showticketingservice.service.PerformanceService;
 import com.show.showticketingservice.service.SeatPriceService;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.Nullable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -61,4 +59,9 @@ public class PerformanceController {
         return performanceService.getPerformanceDetailInfo(performanceId);
     }
 
+    @GetMapping
+    public List<PerformanceResponse> getPerformances(@RequestParam(value = "showType", required = false) ShowType showType,
+                                                     @RequestParam(value = "lastPerfId", required = false) Integer lastPerfId) {
+        return performanceService.getPerformances(showType, lastPerfId);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -1,10 +1,15 @@
 package com.show.showticketingservice.mapper;
 
+import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceRequest;
 import com.show.showticketingservice.model.performance.PerformanceDetailInfoResponse;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
 import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
 
 @Mapper
 public interface PerformanceMapper {
@@ -24,4 +29,8 @@ public interface PerformanceMapper {
     void updatePerformanceInfo(int performanceId, PerformanceUpdateRequest perfUpdateRequest);
 
     PerformanceDetailInfoResponse getPerformanceDetailInfo(int performanceId);
+
+    List<PerformanceResponse> getPerformances(ShowType showType, @Param("pagination") PerformancePagingCriteria performancePagingCriteria);
+
+    boolean isPerfIdAndShowTypeExists(ShowType showType, Integer lastPerfId);
 }

--- a/src/main/java/com/show/showticketingservice/model/criteria/PerformancePagingCriteria.java
+++ b/src/main/java/com/show/showticketingservice/model/criteria/PerformancePagingCriteria.java
@@ -1,0 +1,15 @@
+package com.show.showticketingservice.model.criteria;
+
+import lombok.Getter;
+
+@Getter
+public class PerformancePagingCriteria {
+
+    private final int amount = 10;
+
+    private final Integer lastPerfId;
+
+    public PerformancePagingCriteria(Integer lastPerfId) {
+        this.lastPerfId = lastPerfId;
+    }
+}

--- a/src/main/java/com/show/showticketingservice/model/criteria/PerformancePagingCriteria.java
+++ b/src/main/java/com/show/showticketingservice/model/criteria/PerformancePagingCriteria.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class PerformancePagingCriteria {
 
-    private final int amount = 10;
+    private final static int amount = 10;
 
     private final Integer lastPerfId;
 

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformancePeriod.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformancePeriod.java
@@ -1,0 +1,14 @@
+package com.show.showticketingservice.model.performance;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PerformancePeriod {
+
+    private String firstDay;
+
+    private String lastDay;
+}

--- a/src/main/java/com/show/showticketingservice/model/performance/PerformanceResponse.java
+++ b/src/main/java/com/show/showticketingservice/model/performance/PerformanceResponse.java
@@ -1,0 +1,22 @@
+package com.show.showticketingservice.model.performance;
+
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PerformanceResponse {
+
+    private int id;
+
+    private String title;
+
+    private String imageFilePath;
+
+    private String venueName;
+
+    private String hallName;
+
+    private PerformancePeriod performancePeriod;
+}

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -193,10 +193,10 @@ public class PerformanceService {
     /*
     공연 정보 리스트 조회 캐시 기능
     cacheNames
-    MAIN_PERFORMANCE_LIST : 첫 번째 페이지고 공연 타입을 선택했을 경우
-    PERFORMANCE_LIST : 첫 번째 페이지를 제외하고 공연 타입을 선택했을 경우
-    ALL_TYPE_MAIN_PERFORMANCE_LIST : 첫 번째 페이지고 공연 타입을 선택하지 않아 모든 타입의 공연을 보여줄 경우
-    ALL_TYPE_PERFORMANCE_LIST : 첫 번째 페이지를 제외하고 공연 타입을 선택하지 않아 모든 타입의 공연을 보여줄 경우
+      - MAIN_PERFORMANCE_LIST : 공연 타입을 선택했고 첫 번째 페이지인 경우
+      - PERFORMANCE_LIST : 공연 타입을 선택했고 첫 번째 페이지를 제외한 경우
+      - ALL_TYPE_MAIN_PERFORMANCE_LIST : 모든 타입의 공연을 선택했고 첫 번째 페이지인 경우
+      - ALL_TYPE_PERFORMANCE_LIST : 모든 타입의 공연을 선택했고 첫 번째 페이지를 제외한 경우
      */
     @Caching(cacheable = {
             @Cacheable(

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -220,9 +220,9 @@ public class PerformanceService {
                     key = "#lastPerfId"
             )
     })
-    public List<PerformanceResponse> getPerformances(ShowType showType, Integer lastPerfId) {
-        checkValidPerfIdAndShowType(showType, lastPerfId);
-        return performanceMapper.getPerformances(showType, new PerformancePagingCriteria(lastPerfId));
+    public List<PerformanceResponse> getPerformances(ShowType showType, PerformancePagingCriteria performancePagingCriteria) {
+        checkValidPerfIdAndShowType(showType, performancePagingCriteria.getLastPerfId());
+        return performanceMapper.getPerformances(showType, performancePagingCriteria);
     }
 
     private void checkValidPerfIdAndShowType(ShowType showType, Integer lastPerfId) {

--- a/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
@@ -5,4 +5,15 @@ public class CacheConstant {
     public static final String VENUE = "venue";
 
     public static final String PERFORMANCE = "performance";
+
+    public static final String PERFORMANCE_LIST = "performanceList";
+
+    public static final String MAIN_PERFORMANCE_LIST = "mainPerformanceList";
+
+    public static final String ALL_TYPE_PERFORMANCE_LIST = "allTypePerformanceList";
+
+    public static final String ALL_TYPE_MAIN_PERFORMANCE_LIST = "allTypeMainPerformanceList";
+
+    public static final String ALL_TYPE_MAIN_PERFORMANCE_LIST_KEY = "'allTypeMainPerformanceListKey'";
+
 }

--- a/src/main/java/com/show/showticketingservice/tool/converter/StringToShowTypeConverter.java
+++ b/src/main/java/com/show/showticketingservice/tool/converter/StringToShowTypeConverter.java
@@ -1,0 +1,15 @@
+package com.show.showticketingservice.tool.converter;
+
+import com.show.showticketingservice.model.enumerations.ShowType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToShowTypeConverter implements Converter<String, ShowType> {
+
+    @Override
+    public ShowType convert(String showType) {
+
+        return ShowType.valueOf(Integer.valueOf(showType));
+    }
+}

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -120,7 +120,7 @@
         <result column="venueName" property="venueName"/>
         <result column="hallName" property="hallName"/>
         <association property="performancePeriod"
-                     column="performanceId"
+                     column="id"
                      javaType="com.show.showticketingservice.model.performance.PerformancePeriod"
                      select="getPerfTime">
         </association>
@@ -148,10 +148,10 @@
         ORDER BY p.id DESC
         LIMIT #{pagination.amount}
     </select>
-    
+
     <select id="getPerfTime" resultType="com.show.showticketingservice.model.performance.PerformancePeriod">
         SELECT
-            MIN(startTime) AS firstDay, MAX(startTime) AS lastDay
+            DATE(MIN(startTime)) AS firstDay, DATE(MAX(startTime)) AS lastDay
         FROM performanceTime
         WHERE performanceId = #{id}
     </select>

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -97,4 +97,63 @@
         WHERE p.id = #{performanceId}
     </select>
 
+    <select id="isPerfIdAndShowTypeExists" resultType="boolean">
+        SELECT EXISTS
+        (
+        SELECT * FROM performance
+        <if test="lastPerfId != null and showType != null">
+            WHERE id = #{lastPerfId} AND showType = #{showType}
+        </if>
+        <if test="lastPerfId != null and showType == null">
+            WHERE id = #{lastPerfId}
+        </if>
+        <if test="lastPerfId == null and showType != null">
+            WHERE showType = #{showType}
+        </if>
+        )
+    </select>
+
+    <resultMap id="performanceResponse" type="com.show.showticketingservice.model.performance.PerformanceResponse">
+        <id column="id" property="id"/>
+        <result column="title" property="title"/>
+        <result column="imageFilePath" property="imageFilePath"/>
+        <result column="venueName" property="venueName"/>
+        <result column="hallName" property="hallName"/>
+        <association property="performancePeriod"
+                     column="performanceId"
+                     javaType="com.show.showticketingservice.model.performance.PerformancePeriod"
+                     select="getPerfTime">
+        </association>
+    </resultMap>
+
+    <select id="getPerformances" resultMap="performanceResponse" parameterType="map">
+        SELECT
+            p.id AS id,
+            p.title AS title,
+            p.imageFilePath AS imageFilePath,
+            v.name AS venueName,
+            vh.name AS hallName
+        FROM performance p
+        INNER JOIN venue v ON p.venueId = v.id
+        INNER JOIN venueHall vh ON p.hallId = vh.id
+        <if test="pagination.lastPerfId != null and showType != null">
+            WHERE p.id <![CDATA[<]]> #{pagination.lastPerfId} AND showType = #{showType}
+        </if>
+        <if test="pagination.lastPerfId != null and showType == null">
+            WHERE p.id <![CDATA[<]]> #{pagination.lastPerfId}
+        </if>
+        <if test="pagination.lastPerfId == null and showType != null">
+            WHERE showType = #{showType}
+        </if>
+        ORDER BY p.id DESC
+        LIMIT #{pagination.amount}
+    </select>
+    
+    <select id="getPerfTime" resultType="com.show.showticketingservice.model.performance.PerformancePeriod">
+        SELECT
+            MIN(startTime) AS firstDay, MAX(startTime) AS lastDay
+        FROM performanceTime
+        WHERE performanceId = #{id}
+    </select>
+
 </mapper>

--- a/src/test/java/com/show/showticketingservice/service/PerformanceServiceTest.java
+++ b/src/test/java/com/show/showticketingservice/service/PerformanceServiceTest.java
@@ -1,0 +1,97 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.exception.performance.PerformanceNotExistsException;
+import com.show.showticketingservice.mapper.PerformanceMapper;
+import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
+import com.show.showticketingservice.model.enumerations.ShowType;
+import com.show.showticketingservice.model.performance.PerformancePeriod;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.ArrayList;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PerformanceServiceTest {
+
+    @Mock
+    PerformanceMapper performanceMapper;
+
+    @InjectMocks
+    PerformanceService performanceService;
+
+    @Test
+    @DisplayName("첫 페이지의 모든 공연 타입 정보 리스트 조회를 성공합니다.")
+    public void getPerformanceListSuccess() {
+
+        PerformancePeriod performancePeriod = PerformancePeriod.builder()
+                .firstDay("2021-05-04")
+                .lastDay("2021-06-04")
+                .build();
+
+        PerformanceResponse performanceResponse = PerformanceResponse.builder()
+                .id(1)
+                .venueName("공연장1")
+                .hallName("A홀")
+                .title("피터팬")
+                .imageFilePath(null)
+                .performancePeriod(performancePeriod)
+                .build();
+
+        ShowType showType = null;
+        Integer lastPerfId = null;
+        PerformancePagingCriteria performancePagingCriteria = new PerformancePagingCriteria(lastPerfId);
+
+        List<PerformanceResponse> performanceResponses = new ArrayList<>();
+        performanceResponses.add(performanceResponse);
+
+        when(performanceMapper.isPerfIdAndShowTypeExists(showType, lastPerfId)).thenReturn(true);
+        when(performanceMapper.getPerformances(showType, performancePagingCriteria)).thenReturn(performanceResponses);
+        List<PerformanceResponse> resultPerformanceResponses = performanceService.getPerformances(showType, performancePagingCriteria);
+
+        verify(performanceMapper, times(1)).isPerfIdAndShowTypeExists(showType, lastPerfId);
+        verify(performanceMapper, times(1)).getPerformances(showType, performancePagingCriteria);
+        assertEquals(performanceResponses, resultPerformanceResponses);
+    }
+
+    @Test
+    @DisplayName("페이지 기능을 처리할 공연 id가 존재하지 않습니다.")
+    public void getPerformanceListFailPageFunctionIdNotExists() {
+        PerformancePeriod performancePeriod = PerformancePeriod.builder()
+                .firstDay("2021-05-04")
+                .lastDay("2021-06-04")
+                .build();
+
+        PerformanceResponse performanceResponse = PerformanceResponse.builder()
+                .id(100)
+                .venueName("공연장1")
+                .hallName("A홀")
+                .title("피터팬")
+                .imageFilePath(null)
+                .performancePeriod(performancePeriod)
+                .build();
+
+        ShowType showType = null;
+        Integer lastPerfId = null;
+        PerformancePagingCriteria performancePagingCriteria = new PerformancePagingCriteria(lastPerfId);
+
+        List<PerformanceResponse> performanceResponses = new ArrayList<>();
+        performanceResponses.add(performanceResponse);
+
+        when(performanceMapper.isPerfIdAndShowTypeExists(showType, lastPerfId)).thenReturn(false);
+
+        assertThrows(PerformanceNotExistsException.class, () -> {
+            performanceService.getPerformances(showType, performancePagingCriteria);
+        });
+
+        verify(performanceMapper, times(1)).isPerfIdAndShowTypeExists(showType, lastPerfId);
+
+    }
+}


### PR DESCRIPTION
 1. PerformanceController

    * RequestParam으로 공연 타입(showType)의 정보를 받음. 만약 받지 않을 시 null 값을 받아 전체 페이지 기능을 해준다.
    * RequestParam으로 한 페이지에서의 마지막 공연 Id를 받아 페이징 기능을 해준다. 만약 받지 않을 시 null 값을 받아 첫 번째 페이지 기능을 해준다.
    
 2. PerformanceService
    * checkValidPerfIdAndShowType : 공연 타입과 공연 마지막 id로 페이지 기능을 해줄 정보가 있는지 체크해 준다.
    * getPerformances : 공연 정보 리스트들을 전체 타입 또는 타입 별로 보여준다. 그리고 공연 리스트들은 USER들이 조회할 경우가 많아 캐시를 적용
    * 공연 정보 리스트 조회 캐시 기능
       cacheNames :
         - MAIN_PERFORMANCE_LIST : 공연 타입을 선택했고 첫 번째 페이지인 경우
         - PERFORMANCE_LIST : 공연 타입을 선택했고 첫 번째 페이지를 제외한 경우
         - ALL_TYPE_MAIN_PERFORMANCE_LIST : 모든 타입의 공연을 선택했고 첫 번째 페이지인 경우
         - ALL_TYPE_PERFORMANCE_LIST : 모든 타입의 공연을 선택했고 첫 번째 페이지를 제외한 경우

 3. PerformanceMapper.xml
    * getPerformances(id)
        - 공연 id, 이름, 이미지, 공연장 이름, 공연 홀 이름을 응답함
        - 공연에 연결된 공연 홀과 공연장의 정보를 join하여 불러옴
        - 공연 타입 null x / 마지막id null x 경우 공연 타입을 구분하여 첫 번째 페이지를 제외한 나머지 페이지를 불러 옴
        - 공연 타입 null o / 마지막id null x 경우 모든 공연 타입과 첫 번째 페이지를 제외한 나머지 페이지를 불러 옴
        - 공연 타입 null x / 마지막id null o 경우 공연 타입을 구분하여 첫 번째 페이지를 불러 옴
        - 공연 타입 null o / 마지막id null o 경우 모든 공연 타입과 첫 번째 페이지를 불러 옴 (if문 처리 안함)
    * isPerfIdAndShowTypeExists(id) : 공연 타입 별로 페이지를 처리 할 id가 있는지 체크
   
 4. StringToShowTypeConverter : showType 같은 경우 enum 타입인데 클라이언트에서 RequestParam으로 요청 시 string으로 받기 때문에 여기서 enum으로 전환 시켜줌

 5. 캐시 
    * 공연 리스트 같은 경우 많은 유저들이 동시에 접근할 가능성이 있어서 부화를 방지하기 위해 캐시를 적용
    * 캐시 소멸 시간 cacheNames 
         - ALL_TYPE_MAIN_PERFORMANCE_LIST : 20초
         - MAIN_PERFORMANCE_LIST : 15초 
         - ALL_TYPE_PERFORMANCE_LIST : 10초
         - PERFORMANCE_LIST : 5초
   => 공연 정보 추가 시 향후 페이지 간의 동기화를 유지시키기 위해 캐시 소멸 시간을 위처럼 적용했고 캐시를 비슷한 시간으로 함께 소멸되는 걸 목표로 했다. 
 6. 기능
    * 커서 기반으로 페이징 처리를 해줌
        - 커서 기반 같은 경우 한 페이지 내에서 마지막 요소의 id를 기준으로 하기 때문에 프론트에서는 id를 요청해 줘야 함
        - 첫 번째 페이지는 마지막 id가 null일 경우로 생각하여 로직을 구현
    * 공연 타입을 전체 또는 타입별로 조회를 할 수 있다.
        - 1:MUSICAL, 2:THEATRICAL, 3:CONCERT, null: 전체로 프론트에서 showType을 1 or 2 or 3 or null 요청
    *  공연 스케줄은 처음 시작하는 날짜와 마지막에 시작하는 날짜로 응답하게 함(처음 시작하는 날짜와 마지막에 시작하는 날짜가 같을 시 같은 값으로 보냄)
***
### 기능 리스트
- [x]  공연 리스트 조회 기능 구현
- [x]  캐시 적용
- [x]  커서 기반 페이지 적용
- [x]  테스트 코드 작성