### PR TITLE
[#74] 찜 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -52,12 +52,18 @@ public class RedisCacheConfig {
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
 
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
+
         redisCacheConfigMap.put(CacheConstant.VENUE, redisCacheConfig.entryTtl(Duration.ofHours(2L)));
+
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofDays(1L)));
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(5L)));
         redisCacheConfigMap.put(CacheConstant.MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(15L)));
         redisCacheConfigMap.put(CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(20L)));
         redisCacheConfigMap.put(CacheConstant.ALL_TYPE_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
+
+        redisCacheConfigMap.put(CacheConstant.MAIN_PICK_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(30L)));
+        redisCacheConfigMap.put(CacheConstant.TYPED_PICK_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(10L)));
+
         return RedisCacheManager.builder(redisConnectionFactory)
                 .withInitialCacheConfigurations(redisCacheConfigMap)
                 .build();

--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -54,15 +54,11 @@ public class RedisCacheConfig {
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
 
         redisCacheConfigMap.put(CacheConstant.VENUE, redisCacheConfig.entryTtl(Duration.ofHours(2L)));
-
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofDays(1L)));
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(5L)));
         redisCacheConfigMap.put(CacheConstant.MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(15L)));
         redisCacheConfigMap.put(CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(20L)));
         redisCacheConfigMap.put(CacheConstant.ALL_TYPE_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
-
-        redisCacheConfigMap.put(CacheConstant.MAIN_PICK_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(30L)));
-        redisCacheConfigMap.put(CacheConstant.TYPED_PICK_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(10L)));
 
         return RedisCacheManager.builder(redisConnectionFactory)
                 .withInitialCacheConfigurations(redisCacheConfigMap)

--- a/src/main/java/com/show/showticketingservice/controller/PickController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PickController.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.enumerations.AccessRoles;
+import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceResponse;
 import com.show.showticketingservice.model.pick.PickRequest;
 import com.show.showticketingservice.model.user.UserSession;
@@ -35,8 +36,9 @@ public class PickController {
     @GetMapping
     @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
     public List<PerformanceResponse> getPicks(@CurrentUser UserSession userSession,
+                                              @RequestParam(value = "showType", required = false) ShowType showType,
                                               @RequestParam(value = "lastPerfId", required = false) Integer lastPerfId) {
-        return pickService.getPicks(userSession.getUserId(), new PerformancePagingCriteria(lastPerfId));
+        return pickService.getPicks(userSession.getUserId(), showType, new PerformancePagingCriteria(lastPerfId));
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/controller/PickController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PickController.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.controller;
 
+import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.enumerations.AccessRoles;
 import com.show.showticketingservice.model.performance.PerformanceResponse;
 import com.show.showticketingservice.model.pick.PickRequest;
@@ -33,8 +34,9 @@ public class PickController {
 
     @GetMapping
     @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
-    public List<PerformanceResponse> getPicks(@CurrentUser UserSession userSession) {
-        return pickService.getPicks(userSession.getUserId());
+    public List<PerformanceResponse> getPicks(@CurrentUser UserSession userSession,
+                                              @RequestParam(value = "lastPerfId", required = false) Integer lastPerfId) {
+        return pickService.getPicks(userSession.getUserId(), new PerformancePagingCriteria(lastPerfId));
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/controller/PickController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PickController.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
 import com.show.showticketingservice.model.pick.PickRequest;
 import com.show.showticketingservice.model.user.UserSession;
 import com.show.showticketingservice.service.PickService;
@@ -8,6 +9,8 @@ import com.show.showticketingservice.tool.annotation.CurrentUser;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,4 +30,11 @@ public class PickController {
     public void deletePick(@CurrentUser UserSession userSession, @PathVariable int performanceId) {
         pickService.deletePick(userSession.getUserId(), performanceId);
     }
+
+    @GetMapping
+    @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
+    public List<PerformanceResponse> getPicks(@CurrentUser UserSession userSession) {
+        return pickService.getPicks(userSession.getUserId());
+    }
+
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -36,6 +36,6 @@ public interface PerformanceMapper {
 
     boolean isPerfIdAndShowTypeExists(ShowType showType, Integer lastPerfId);
 
-    List<PerformanceResponse> getPickedPerformances(int userId, @Param("pagination") PerformancePagingCriteria performancePagingCriteria);
+    List<PerformanceResponse> getPickedPerformances(int userId, ShowType showType, @Param("pagination") PerformancePagingCriteria performancePagingCriteria);
 
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -36,4 +36,6 @@ public interface PerformanceMapper {
 
     boolean isPerfIdAndShowTypeExists(ShowType showType, Integer lastPerfId);
 
+    List<PerformanceResponse> getPickedPerformances(int userId);
+
 }

--- a/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PerformanceMapper.java
@@ -36,6 +36,6 @@ public interface PerformanceMapper {
 
     boolean isPerfIdAndShowTypeExists(ShowType showType, Integer lastPerfId);
 
-    List<PerformanceResponse> getPickedPerformances(int userId);
+    List<PerformanceResponse> getPickedPerformances(int userId, @Param("pagination") PerformancePagingCriteria performancePagingCriteria);
 
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -306,7 +306,7 @@ public class PerformanceService {
         performanceMapper.deletePerformance(performanceId);
     }
 
-    public List<PerformanceResponse> getPickedPerformances(int userId) {
-        return performanceMapper.getPickedPerformances(userId);
+    public List<PerformanceResponse> getPickedPerformances(int userId, PerformancePagingCriteria performancePagingCriteria) {
+        return performanceMapper.getPickedPerformances(userId, performancePagingCriteria);
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -306,7 +306,8 @@ public class PerformanceService {
         performanceMapper.deletePerformance(performanceId);
     }
 
-    public List<PerformanceResponse> getPickedPerformances(int userId, PerformancePagingCriteria performancePagingCriteria) {
-        return performanceMapper.getPickedPerformances(userId, performancePagingCriteria);
+    public List<PerformanceResponse> getPickedPerformances(int userId, ShowType showType, PerformancePagingCriteria performancePagingCriteria) {
+        return performanceMapper.getPickedPerformances(userId, showType, performancePagingCriteria);
     }
+
 }

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -5,18 +5,11 @@ import com.show.showticketingservice.exception.performance.PerformanceNotExistsE
 import com.show.showticketingservice.exception.performance.PerformanceTimeConflictException;
 import com.show.showticketingservice.mapper.PerformanceMapper;
 import com.show.showticketingservice.mapper.PerformanceTimeMapper;
+import com.show.showticketingservice.mapper.SeatMapper;
 import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.*;
-import com.show.showticketingservice.mapper.SeatMapper;
-import com.show.showticketingservice.model.enumerations.ShowType;
-import com.show.showticketingservice.model.performance.PerformanceRequest;
-import com.show.showticketingservice.model.performance.PerformanceDetailInfoResponse;
-import com.show.showticketingservice.model.performance.PerformanceTimeRequest;
-import com.show.showticketingservice.model.performance.SeatPriceRowNumData;
-import com.show.showticketingservice.model.performance.SeatRequest;
 import com.show.showticketingservice.model.venueHall.VenueHallColumnSeat;
-import com.show.showticketingservice.model.performance.PerformanceUpdateRequest;
 import com.show.showticketingservice.tool.constants.CacheConstant;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
@@ -25,12 +18,14 @@ import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import static com.show.showticketingservice.tool.constants.CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST_KEY;
 import java.util.stream.IntStream;
+
+import static com.show.showticketingservice.tool.constants.CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST_KEY;
 
 @Service
 @RequiredArgsConstructor
@@ -311,4 +306,7 @@ public class PerformanceService {
         performanceMapper.deletePerformance(performanceId);
     }
 
+    public List<PerformanceResponse> getPickedPerformances(int userId) {
+        return performanceMapper.getPickedPerformances(userId);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -2,8 +2,11 @@ package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.pick.PickAlreadyExistsException;
 import com.show.showticketingservice.mapper.PickMapper;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,4 +34,9 @@ public class PickService {
     public void deletePick(int userId, int performanceId) {
         pickMapper.deletePick(userId, performanceId);
     }
+
+    public List<PerformanceResponse> getPicks(int userId) {
+        return performanceService.getPickedPerformances(userId);
+    }
+
 }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -2,6 +2,7 @@ package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.pick.PickAlreadyExistsException;
 import com.show.showticketingservice.mapper.PickMapper;
+import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.performance.PerformanceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,8 +26,8 @@ public class PickService {
         pickMapper.insertPick(userId, performanceId);
     }
 
-    private void checkPickDuplicated(int userNum, int performanceId) {
-        if (pickMapper.isPickExists(userNum, performanceId)) {
+    private void checkPickDuplicated(int userId, int performanceId) {
+        if (pickMapper.isPickExists(userId, performanceId)) {
             throw new PickAlreadyExistsException();
         }
     }
@@ -35,8 +36,8 @@ public class PickService {
         pickMapper.deletePick(userId, performanceId);
     }
 
-    public List<PerformanceResponse> getPicks(int userId) {
-        return performanceService.getPickedPerformances(userId);
+    public List<PerformanceResponse> getPicks(int userId, PerformancePagingCriteria performancePagingCriteria) {
+        return performanceService.getPickedPerformances(userId, performancePagingCriteria);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -5,7 +5,11 @@ import com.show.showticketingservice.mapper.PickMapper;
 import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceResponse;
+import com.show.showticketingservice.tool.constants.CacheConstant;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +24,10 @@ public class PickService {
     private final PickMapper pickMapper;
 
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheConstant.MAIN_PICK_LIST),
+            @CacheEvict(cacheNames = CacheConstant.TYPED_PICK_LIST, allEntries = true)
+    })
     public void insertPick(int userId, int performanceId) {
 
         performanceService.checkValidPerformanceId(performanceId);
@@ -35,11 +43,24 @@ public class PickService {
         }
     }
 
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheConstant.MAIN_PICK_LIST),
+            @CacheEvict(cacheNames = CacheConstant.TYPED_PICK_LIST, allEntries = true)
+    })
     public void deletePick(int userId, int performanceId) {
         pickMapper.deletePick(userId, performanceId);
     }
 
     @Transactional(readOnly = true)
+    @Caching(cacheable = {
+            @Cacheable(
+                    cacheNames = CacheConstant.MAIN_PICK_LIST,
+                    condition = "#showType == null && #performancePagingCriteria.lastPerfId == null"),
+            @Cacheable(
+                    cacheNames = CacheConstant.TYPED_PICK_LIST,
+                    condition = "#showType != null && #performancePagingCriteria.lastPerfId == null",
+                    key = "#showType.toString()"),
+    })
     public List<PerformanceResponse> getPicks(int userId, ShowType showType, PerformancePagingCriteria performancePagingCriteria) {
         return performanceService.getPickedPerformances(userId, showType, performancePagingCriteria);
     }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -5,11 +5,7 @@ import com.show.showticketingservice.mapper.PickMapper;
 import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
 import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceResponse;
-import com.show.showticketingservice.tool.constants.CacheConstant;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,10 +20,6 @@ public class PickService {
     private final PickMapper pickMapper;
 
     @Transactional
-    @Caching(evict = {
-            @CacheEvict(cacheNames = CacheConstant.MAIN_PICK_LIST),
-            @CacheEvict(cacheNames = CacheConstant.TYPED_PICK_LIST, allEntries = true)
-    })
     public void insertPick(int userId, int performanceId) {
 
         performanceService.checkValidPerformanceId(performanceId);
@@ -43,24 +35,11 @@ public class PickService {
         }
     }
 
-    @Caching(evict = {
-            @CacheEvict(cacheNames = CacheConstant.MAIN_PICK_LIST),
-            @CacheEvict(cacheNames = CacheConstant.TYPED_PICK_LIST, allEntries = true)
-    })
     public void deletePick(int userId, int performanceId) {
         pickMapper.deletePick(userId, performanceId);
     }
 
     @Transactional(readOnly = true)
-    @Caching(cacheable = {
-            @Cacheable(
-                    cacheNames = CacheConstant.MAIN_PICK_LIST,
-                    condition = "#showType == null && #performancePagingCriteria.lastPerfId == null"),
-            @Cacheable(
-                    cacheNames = CacheConstant.TYPED_PICK_LIST,
-                    condition = "#showType != null && #performancePagingCriteria.lastPerfId == null",
-                    key = "#showType.toString()"),
-    })
     public List<PerformanceResponse> getPicks(int userId, ShowType showType, PerformancePagingCriteria performancePagingCriteria) {
         return performanceService.getPickedPerformances(userId, showType, performancePagingCriteria);
     }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -7,6 +7,7 @@ import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,6 +19,7 @@ public class PickService {
 
     private final PickMapper pickMapper;
 
+    @Transactional
     public void insertPick(int userId, int performanceId) {
 
         performanceService.checkValidPerformanceId(performanceId);
@@ -37,6 +39,7 @@ public class PickService {
         pickMapper.deletePick(userId, performanceId);
     }
 
+    @Transactional(readOnly = true)
     public List<PerformanceResponse> getPicks(int userId, ShowType showType, PerformancePagingCriteria performancePagingCriteria) {
         return performanceService.getPickedPerformances(userId, showType, performancePagingCriteria);
     }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -3,6 +3,7 @@ package com.show.showticketingservice.service;
 import com.show.showticketingservice.exception.pick.PickAlreadyExistsException;
 import com.show.showticketingservice.mapper.PickMapper;
 import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
+import com.show.showticketingservice.model.enumerations.ShowType;
 import com.show.showticketingservice.model.performance.PerformanceResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,8 +37,8 @@ public class PickService {
         pickMapper.deletePick(userId, performanceId);
     }
 
-    public List<PerformanceResponse> getPicks(int userId, PerformancePagingCriteria performancePagingCriteria) {
-        return performanceService.getPickedPerformances(userId, performancePagingCriteria);
+    public List<PerformanceResponse> getPicks(int userId, ShowType showType, PerformancePagingCriteria performancePagingCriteria) {
+        return performanceService.getPickedPerformances(userId, showType, performancePagingCriteria);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
@@ -16,4 +16,8 @@ public class CacheConstant {
 
     public static final String ALL_TYPE_MAIN_PERFORMANCE_LIST_KEY = "'allTypeMainPerformanceListKey'";
 
+    public static final String MAIN_PICK_LIST = "mainPickList";
+
+    public static final String TYPED_PICK_LIST = "typedPickList";
+
 }

--- a/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
@@ -16,8 +16,4 @@ public class CacheConstant {
 
     public static final String ALL_TYPE_MAIN_PERFORMANCE_LIST_KEY = "'allTypeMainPerformanceListKey'";
 
-    public static final String MAIN_PICK_LIST = "mainPickList";
-
-    public static final String TYPED_PICK_LIST = "typedPickList";
-
 }

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -183,6 +183,9 @@
         WHERE p.id IN ( SELECT performanceId
                         FROM pick
                         WHERE userId = #{userId})
+        <if test="showType != null">
+            AND p.showType = #{showType}
+        </if>
         <if test="pagination.lastPerfId != null">
             AND p.id <![CDATA[<]]> #{pagination.lastPerfId}
         </if>

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -183,7 +183,11 @@
         WHERE p.id IN ( SELECT performanceId
                         FROM pick
                         WHERE userId = #{userId})
+        <if test="pagination.lastPerfId != null">
+            AND p.id <![CDATA[<]]> #{pagination.lastPerfId}
+        </if>
         ORDER BY p.id DESC
+        LIMIT #{pagination.amount}
     </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mappers/PerformanceMapper.xml
+++ b/src/main/resources/mybatis/mappers/PerformanceMapper.xml
@@ -170,4 +170,20 @@
         WHERE performanceId = #{id}
     </select>
 
+    <select id="getPickedPerformances" resultMap="performanceResponse">
+        SELECT
+            p.id AS id,
+            p.title AS title,
+            p.imageFilePath AS imageFilePath,
+            v.name AS venueName,
+            vh.name AS hallName
+        FROM performance p
+        INNER JOIN venue v ON p.venueId = v.id
+        INNER JOIN venueHall vh ON p.hallId = vh.id
+        WHERE p.id IN ( SELECT performanceId
+                        FROM pick
+                        WHERE userId = #{userId})
+        ORDER BY p.id DESC
+    </select>
+
 </mapper>

--- a/src/test/java/com/show/showticketingservice/service/PickServiceTest.java
+++ b/src/test/java/com/show/showticketingservice/service/PickServiceTest.java
@@ -1,0 +1,156 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.exception.performance.PerformanceNotExistsException;
+import com.show.showticketingservice.exception.pick.PickAlreadyExistsException;
+import com.show.showticketingservice.mapper.PickMapper;
+import com.show.showticketingservice.model.criteria.PerformancePagingCriteria;
+import com.show.showticketingservice.model.enumerations.ShowType;
+import com.show.showticketingservice.model.performance.PerformancePeriod;
+import com.show.showticketingservice.model.performance.PerformanceResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class PickServiceTest {
+
+    public static final int USER_NUM = 1;
+
+    public static final int PERF_NUM = 11;
+
+    @Mock
+    private PickMapper pickMapper;
+
+    @Mock
+    private PerformanceService performanceService;
+
+    @InjectMocks
+    private PickService pickService;
+
+    @Test
+    @DisplayName("찜 목록 추가 성공")
+    public void insertPick() {
+
+        willDoNothing().given(performanceService).checkValidPerformanceId(PERF_NUM);
+        given(pickMapper.isPickExists(USER_NUM, PERF_NUM)).willReturn(false);
+
+        pickService.insertPick(USER_NUM, PERF_NUM);
+
+        verify(pickMapper).insertPick(USER_NUM, PERF_NUM);
+    }
+
+    @Test
+    @DisplayName("찜 추가 실패 - 해당 공연이 존재하지 않는 경우")
+    public void insertPickWithInvalidPerf() {
+
+        willThrow(PerformanceNotExistsException.class).given(performanceService).checkValidPerformanceId(PERF_NUM);
+
+        assertThrows(PerformanceNotExistsException.class, () -> {
+            pickService.insertPick(USER_NUM, PERF_NUM);
+        });
+
+        verify(pickMapper, never()).insertPick(USER_NUM, PERF_NUM);
+    }
+
+    @Test
+    @DisplayName("찜 추가 실패 - 이미 추가된 공연을 중복 추가 하는 경우")
+    public void insertPickWithDuplicatedPerf() {
+
+        willDoNothing().given(performanceService).checkValidPerformanceId(PERF_NUM);
+        given(pickMapper.isPickExists(USER_NUM, PERF_NUM)).willReturn(true);
+
+        assertThrows(PickAlreadyExistsException.class, () -> {
+            pickService.insertPick(USER_NUM, PERF_NUM);
+        });
+
+        verify(pickMapper, never()).insertPick(USER_NUM, PERF_NUM);
+    }
+
+    @Test
+    @DisplayName("단일 찜 목록 삭제 성공")
+    public void deletePick() {
+        pickService.deletePick(USER_NUM, PERF_NUM);
+
+        verify(pickMapper).deletePick(USER_NUM, PERF_NUM);
+    }
+
+    @Test
+    @DisplayName("찜 목록 조회 성공 - 찜 목록은 공연ID 역순으로 반환")
+    public void getPickList() {
+
+        int perf1 = 1;
+        int perf2 = 2;
+
+        List<PerformanceResponse> pickList = new ArrayList<>();
+        pickList.add(getPerformance(perf2));
+        pickList.add(getPerformance(perf1));
+
+        ShowType showType = null;
+        Integer lastPerfId = null;
+        PerformancePagingCriteria criteria = new PerformancePagingCriteria(lastPerfId);
+
+        given(performanceService.getPickedPerformances(USER_NUM, showType, criteria)).willReturn(pickList);
+
+        List<PerformanceResponse> pickListResult = pickService.getPicks(USER_NUM, showType, criteria);
+
+        verify(performanceService).getPickedPerformances(USER_NUM, showType, criteria);
+        assertEquals(2, pickListResult.size());
+        assertEquals(pickList, pickListResult);
+    }
+
+    @Test
+    @DisplayName("페이징 적용 찜 목록 조회 성공 - 커서 방식 페이징 / 1번 공연 이후의 찜 리스트 반환")
+    public void getPickListWithPaging() {
+        int perf1 = 1;
+        int perf2 = 2;
+
+        PerformanceResponse excludedPerfPick = getPerformance(perf1);
+
+        List<PerformanceResponse> pickList = new ArrayList<>();
+        pickList.add(getPerformance(perf2));
+        pickList.add(excludedPerfPick);
+        pickList.remove(excludedPerfPick);
+
+        ShowType showType = null;
+        Integer lastPerfId = 1;
+        PerformancePagingCriteria criteria = new PerformancePagingCriteria(lastPerfId);
+
+        given(performanceService.getPickedPerformances(USER_NUM, showType, criteria)).willReturn(pickList);
+
+        List<PerformanceResponse> pickListResult = pickService.getPicks(USER_NUM, showType, criteria);
+
+        verify(performanceService).getPickedPerformances(USER_NUM, showType, criteria);
+        assertEquals(1, pickListResult.size());
+        assertEquals(pickList, pickListResult);
+    }
+
+    private PerformanceResponse getPerformance(int id) {
+        return PerformanceResponse.builder()
+                .id(id)
+                .venueName("테스트 공연장")
+                .hallName("테스트 홀")
+                .title("공연")
+                .imageFilePath(null)
+                .performancePeriod(getPerfPeriod())
+                .build();
+    }
+
+    private PerformancePeriod getPerfPeriod() {
+        return PerformancePeriod.builder()
+                .firstDay("2021-05-01")
+                .lastDay("2021-05-31")
+                .build();
+    }
+
+
+}


### PR DESCRIPTION
#74 

## 개요
- 찜 목록 조회
    - 현재 로그인 된 user의 찜 목록
    - 전체 & 공연타입별 조회 가능
    - 커서(Cursor) 기반 페이징 처리
- _일반 회원 기능_

## Progress
- [x] 기본 찜 목록 조회 
- [x] 커서 방식 페이징 적용
- [x] 공연 타입별 목록 조회
- [x] 테스트 코드

---

1. **찜 목록 조회**
    - 기본적인 서비스 메커니즘은 [#84]**공연 리스트 조회** 기능과 유사
    - pick 테이블의 userId에 매칭되는 공연(performance)를 모두 조회

2.  **커서 기반 페이징 처리**
    - 공연 조회 페이징 설정 관련 `PerformancePagingCriteria` 클래스를 기반으로 직전에 마지막으로 조회된 공연(**lastPerfId**) 이후의 지정된 수(amount) 만큼 찜 목록 반환
    - **lastPerfId**는 RequestParam으로 받고, 만약 Null 일 시 찜 목록의 처음부터 지정된 수 만큼 반환

3. **공연 타입별 목록 조회**
    - 공연타입(**ShowType**)을 RequestParam으로 전달받아 해당 타입의 공연 리턴
    - **ShowType**이 Null 이라면 전체 찜 목록 리턴

4. ~~**캐시 적용**~~
    1. ~~**전체 찜 목록 조회(MAIN_PICK_LIST):**~~
        - ~~첫 찜 목록 페이지~~
        - ~~캐시 유지 시간: 30분~~
        - ~~찜 목록은 모든 공연 리스트를 조회하는 것 보다 데이터 수가 현저히 적음~~
        -  ~~저장된 찜의 공연 정보를 모두 확인하는 시간을 30분이라 예상. (리스트와 각 공연상세 정보 조회를 번갈아가며 확인)~~
    2. ~~**공연 타입 별 찜 목록 조회(TYPED_PICK_LIST):**~~
        - ~~공연 타입을 구분하여 조회하는 첫 페이지~~
        - ~~캐시 유지 시간: 20분~~
        - ~~공연 타입을 구분을 하여 조회를 하면 전체 조회보다도 더 데이터가 줄어들어 상대적으로 전체 찜 목록 조회보다 짧게 설정~~
    3. **etc**
        - ~~찜 목록 추가, 삭제 기능 수행 시 찜 조회 관련 모든 캐시 해제~~
        - ~~조회 중 첫번째 페이지에 대한 것만 캐시 적용~~
        - ~~lastPerfId 값에 따라 페이지를 구분하여 목록을 조회하는 경우엔 적은 데이터량으로 인한 사용 빈도가 낮다고 생각하여 캐시 적용 제외~~
        - **정적인 데이터가 아닌 회원마다 다른 결과를 응답하기 때문에 캐시 적용 불필요**