### PR TITLE
다중 찜 목록 삭제 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/controller/PickController.java
+++ b/src/main/java/com/show/showticketingservice/controller/PickController.java
@@ -33,6 +33,12 @@ public class PickController {
         pickService.deletePick(userSession.getUserId(), performanceId);
     }
 
+    @DeleteMapping
+    @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
+    public void deletePicks(@CurrentUser UserSession userSession, @RequestBody List<Integer> perfIds) {
+        pickService.deletePicks(userSession.getUserId(), perfIds);
+    }
+
     @GetMapping
     @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
     public List<PerformanceResponse> getPicks(@CurrentUser UserSession userSession,

--- a/src/main/java/com/show/showticketingservice/mapper/PickMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/PickMapper.java
@@ -2,6 +2,8 @@ package com.show.showticketingservice.mapper;
 
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
+
 @Mapper
 public interface PickMapper {
 
@@ -10,4 +12,7 @@ public interface PickMapper {
     boolean isPickExists(int userId, int performanceId);
 
     void deletePick(int userId, int performanceId);
+
+    void deletePicks(int userId, List<Integer> perfIds);
+
 }

--- a/src/main/java/com/show/showticketingservice/service/PickService.java
+++ b/src/main/java/com/show/showticketingservice/service/PickService.java
@@ -45,10 +45,16 @@ public class PickService {
 
     @Caching(evict = {
             @CacheEvict(cacheNames = CacheConstant.MAIN_PICK_LIST),
-            @CacheEvict(cacheNames = CacheConstant.TYPED_PICK_LIST, allEntries = true)
-    })
+            @CacheEvict(cacheNames = CacheConstant.TYPED_PICK_LIST, allEntries = true)})
     public void deletePick(int userId, int performanceId) {
         pickMapper.deletePick(userId, performanceId);
+    }
+
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheConstant.MAIN_PICK_LIST),
+            @CacheEvict(cacheNames = CacheConstant.TYPED_PICK_LIST, allEntries = true)})
+    public void deletePicks(int userId, List<Integer> perfIds) {
+        pickMapper.deletePicks(userId, perfIds);
     }
 
     @Transactional(readOnly = true)
@@ -64,5 +70,4 @@ public class PickService {
     public List<PerformanceResponse> getPicks(int userId, ShowType showType, PerformancePagingCriteria performancePagingCriteria) {
         return performanceService.getPickedPerformances(userId, showType, performancePagingCriteria);
     }
-
 }

--- a/src/main/resources/mybatis/mappers/PickMapper.xml
+++ b/src/main/resources/mybatis/mappers/PickMapper.xml
@@ -21,4 +21,13 @@
         WHERE userId = #{userId} AND performanceId = #{performanceId}
     </delete>
 
+    <delete id="deletePicks" parameterType="map">
+        DELETE FROM pick
+        WHERE userId = #{userId}
+        AND performanceId IN
+        <foreach collection="perfIds" item="perfId" open="(" close=")" separator=",">
+            #{perfId}
+        </foreach>
+    </delete>
+
 </mapper>

--- a/src/test/java/com/show/showticketingservice/service/PickServiceTest.java
+++ b/src/test/java/com/show/showticketingservice/service/PickServiceTest.java
@@ -15,7 +15,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -82,6 +84,30 @@ class PickServiceTest {
         pickService.deletePick(USER_NUM, PERF_NUM);
 
         verify(pickMapper).deletePick(USER_NUM, PERF_NUM);
+    }
+
+    @Test
+    @DisplayName("다중 찜 목록 삭제 성공")
+    public void deletePicks() {
+        Map<Integer, Integer> picks = new HashMap<>();
+        picks.put(1, 1);
+        picks.put(2, 2);
+        picks.put(3, 3);
+        picks.put(4, 4);
+
+        List<Integer> perfIds = new ArrayList<>();
+        perfIds.add(1);
+        perfIds.add(2);
+
+        willAnswer(invocationOnMock -> {
+            perfIds.forEach(picks::remove);
+            return null;
+        }).given(pickMapper).deletePicks(USER_NUM, perfIds);
+
+        pickService.deletePicks(USER_NUM, perfIds);
+
+        verify(pickMapper).deletePicks(USER_NUM, perfIds);
+        assertEquals(2, picks.size());
     }
 
     @Test


### PR DESCRIPTION
#89 

## 개요
- 찜 목록 조회를 한 후 조회된 리스트 중 여러 항목을 골라서 삭제하는 기능
- UI에서 유효한 공연id만을 골라서 삭제 요청
- 유효하지 않은 공연id가 전달된다 하더라도 쿼리수행에 문제가 없으므로 별도의 공연id를 체크하는 로직 생략
- _일반 회원 기능_

## Progress

- [x] 다중 찜 목록 삭제 기능 구현
- [x] 테스트 코드 작성

---
- **다중 찜 목록 삭제**
    - Integer형의 삭제할 공연(performanceId) List를 RequestBody로 요청
    - 현재 로그인 된 회원의 userId와 삭제 할 performanceId에 매칭되는 pick 테이블의 데이터 삭제