### PR TITLE
[#107] 공연 스케줄 시간 체크 로직 수정

### DIFF
--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -32,6 +32,8 @@ import static com.show.showticketingservice.tool.constants.CacheConstant.ALL_TYP
 @RequiredArgsConstructor
 public class PerformanceService {
 
+    private static final long MAX_SCHEDULE_TIME = 24_00_00;
+
     private final PerformanceMapper performanceMapper;
 
     private final PerformanceTimeMapper performanceTimeMapper;
@@ -176,7 +178,7 @@ public class PerformanceService {
             throw new PerformanceTimeConflictException("공연 스케줄 시간을 잘못 입력하였습니다.");
         }
 
-        if (endTime - startTime > 24_00_00) {
+        if (endTime - startTime > MAX_SCHEDULE_TIME) {
             throw new PerformanceTimeConflictException("공연 시간은 24시간을 초과할 수 없습니다.");
         }
 


### PR DESCRIPTION
공연 시간이 24시간을 초과하는지 확인하는 로직(`checkCorrectperfTime()`) 중
**시간 값**을 하드코딩하여 유지보수 관점에서 단점이 존재하므로
해당 값을 **상수로 처리**

- 문제 코드:
```
if (endTime - startTime > 24_00_00) {
    ....
}
```