### PR TITLE
[#111] Cache 관련 설정 수정

### DIFF
--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -57,9 +57,13 @@ public class RedisCacheConfig {
         redisCacheConfigMap.put(CacheConstant.MAIN_TYPED_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(30L)));
         redisCacheConfigMap.put(CacheConstant.PAGED_TYPED_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(10L)));
         redisCacheConfigMap.put(CacheConstant.PAGED_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(10L)));
+
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofMinutes(30L)));
+
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE_TIME, redisCacheConfig.entryTtl(Duration.ofMinutes(20L)));
+
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE_REMAINING_SEAT_NUM, redisCacheConfig.entryTtl(Duration.ofSeconds(3L)));
+
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE_SEAT_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(3L)));
 
         return RedisCacheManager.builder(redisConnectionFactory)

--- a/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
+++ b/src/main/java/com/show/showticketingservice/config/RedisCacheConfig.java
@@ -53,14 +53,13 @@ public class RedisCacheConfig {
 
         Map<String, RedisCacheConfiguration> redisCacheConfigMap = new HashMap<>();
 
-        redisCacheConfigMap.put(CacheConstant.VENUE, redisCacheConfig.entryTtl(Duration.ofHours(2L)));
-        redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofDays(1L)));
-        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_TIME, redisCacheConfig.entryTtl(Duration.ofMinutes(5L)));
-        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_SEAT, redisCacheConfig.entryTtl(Duration.ofSeconds(3L)));
-        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(5L)));
-        redisCacheConfigMap.put(CacheConstant.MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(15L)));
-        redisCacheConfigMap.put(CacheConstant.ALL_TYPE_MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(20L)));
-        redisCacheConfigMap.put(CacheConstant.ALL_TYPE_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(10L)));
+        redisCacheConfigMap.put(CacheConstant.MAIN_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofHours(1L)));
+        redisCacheConfigMap.put(CacheConstant.MAIN_TYPED_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(30L)));
+        redisCacheConfigMap.put(CacheConstant.PAGED_TYPED_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(10L)));
+        redisCacheConfigMap.put(CacheConstant.PAGED_PERFORMANCE_LIST, redisCacheConfig.entryTtl(Duration.ofMinutes(10L)));
+        redisCacheConfigMap.put(CacheConstant.PERFORMANCE, redisCacheConfig.entryTtl(Duration.ofMinutes(30L)));
+        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_TIME, redisCacheConfig.entryTtl(Duration.ofMinutes(20L)));
+        redisCacheConfigMap.put(CacheConstant.PERFORMANCE_REMAINING_SEAT_NUM, redisCacheConfig.entryTtl(Duration.ofSeconds(3L)));
         redisCacheConfigMap.put(CacheConstant.PERFORMANCE_SEAT_LIST, redisCacheConfig.entryTtl(Duration.ofSeconds(3L)));
 
         return RedisCacheManager.builder(redisConnectionFactory)

--- a/src/main/java/com/show/showticketingservice/service/VenueService.java
+++ b/src/main/java/com/show/showticketingservice/service/VenueService.java
@@ -44,7 +44,6 @@ public class VenueService {
     }
 
     @Transactional
-    @CacheEvict(cacheNames = CacheConstant.VENUE, key = "#venueId")
     public void updateVenueInfo(int venueId, VenueUpdateRequest venueUpdateRequest) {
 
         checkVenueIdExists(venueId);
@@ -64,7 +63,6 @@ public class VenueService {
     }
 
     @Transactional
-    @CacheEvict(cacheNames = CacheConstant.VENUE, key = "#venueId")
     public void deleteVenue(int venueId) {
         checkVenueIdExists(venueId);
 
@@ -103,7 +101,6 @@ public class VenueService {
     }
 
     @Transactional(readOnly = true)
-    @Cacheable(cacheNames = CacheConstant.VENUE, key = "#venueId")
     public VenueDetailInfoResponse getVenueInfo(int venueId) {
 
         VenueResponse venueResponse = venueMapper.getVenueInfo(venueId);

--- a/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
@@ -6,7 +6,7 @@ public class CacheConstant {
 
     public static final String PERFORMANCE_TIME = "performanceTime";
 
-    public static final String PERFORMANCE_REMAINING_SEAT_NUM = "performanceRemainingSeatsNum";
+    public static final String PERFORMANCE_REMAINING_SEAT_NUM = "performanceRemainingSeatNum";
 
     public static final String MAIN_PERFORMANCE_LIST_KEY = "'mainPerformanceListKey'";
 

--- a/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
+++ b/src/main/java/com/show/showticketingservice/tool/constants/CacheConstant.java
@@ -2,24 +2,22 @@ package com.show.showticketingservice.tool.constants;
 
 public class CacheConstant {
 
-    public static final String VENUE = "venue";
-
     public static final String PERFORMANCE = "performance";
 
     public static final String PERFORMANCE_TIME = "performanceTime";
 
-    public static final String PERFORMANCE_SEAT = "performanceSeat";
+    public static final String PERFORMANCE_REMAINING_SEAT_NUM = "performanceRemainingSeatsNum";
 
-    public static final String PERFORMANCE_LIST = "performanceList";
+    public static final String MAIN_PERFORMANCE_LIST_KEY = "'mainPerformanceListKey'";
+
+    public static final String PERFORMANCE_SEAT_LIST = "performanceSeatList";
 
     public static final String MAIN_PERFORMANCE_LIST = "mainPerformanceList";
 
-    public static final String ALL_TYPE_PERFORMANCE_LIST = "allTypePerformanceList";
+    public static final String MAIN_TYPED_PERFORMANCE_LIST = "mainTypedPerformanceList";
 
-    public static final String ALL_TYPE_MAIN_PERFORMANCE_LIST = "allTypeMainPerformanceList";
+    public static final String PAGED_PERFORMANCE_LIST = "pagedPerformanceList";
 
-    public static final String ALL_TYPE_MAIN_PERFORMANCE_LIST_KEY = "'allTypeMainPerformanceListKey'";
-
-    public static final String PERFORMANCE_SEAT_LIST = "performanceSeatList";
+    public static final String PAGED_TYPED_PERFORMANCE_LIST = "pagedTypedPerformanceList";
 
 }


### PR DESCRIPTION

### 1. 캐시 관련 (공연장 리스트)상수명 의미를 잘 표형할 수 있도록 다음과 같이 변경
   
**- MAIN_PERFORMANCE_LIST**
   (모든 공연 리스트 첫 페이지 / showType X, lastPerfId X / 기존: ALL_TYPE_MAIN_PERFORMANCE_LIST)
 
**- MAIN_TYPED_PERFORMANCE_LIST**
   (공연 타입 지정 공연 리스트 첫 페이지 / showType O, lastPerfId X / 기존: MAIN_PERFORMANCE_LIST)

**- PAGED_PERFORMANCE_LIST**
   (페이징 적용 모든 공연 리스트 / showType X, lastPerfId O / 기존: ALL_TYPE_PERFORMANCE_LIST)

**- PAGED_TYPED_PERFORMANCE_LIST**
   (페이징, 공연 타입 지정 공연장 리스트 / showType O, lastPerfId O / 기존: PERFORMANCE_LIST)

**- PERFORMANCE_REMAINING_SEAT_NUM**
   (잔여 좌석 수 / 기존: PERFORMANCE_SEAT)

### 2. 캐시 유지 시간 변경

**- 공연장(venue) 목록 조회 캐시 미적용**
   공연장 정보는 관리자만 조회 가능하여 빈번한 요청이 오지 않을 것이라 판단

**- PERFORMANCE (30분)**
      공연 상세 정보. 많은 빈도로 요청이 오지만 MAIN_PERFORMANCE_LIST 보단 상대적으로 적음

**- PERFORMANCE_TIME (20분)**
      공연 스케줄 데이터. PERFORMANCE 보다 적은 빈도로 요청

**- PERFORMANCE_REMAING_SEATS_NUM (3초)**
      공연의 특정 스케줄에 대한 잔여 좌석 수 정보. 공연 예매에 따라 변동성이 아주 크므로 캐싱 시간을 초단위로 작게 설정.(예매 
       관련 작업 수행시 캐시 해제 필요)

**- MAIN_PERFORMANCE_LIST (1시간)**
      메인 화면에 표시되므로 모든 회원 및 서비스를 이용하는 모든 사용자가 필연적 가장 많이 조회하므로 가장 긴 1시간 적용

**- MAIN_TYPED_PERFORMANCE_LIST (30분)**
      공연 타입을 구분했을 때 첫 페이지를 확인하는 것은 MAIN_PERFORMANCE_LIST 보다는 적은 빈도로 요청

**- PAGED_PERFORMANCE_LIST (10분)**
      페이지 지정을 하여 조회하는 빈도는 윗 페이지일수록 빈도수가 많지만, 각 페이지마다 모두 캐싱을 했을시 유지 시간이 길다 
      면 캐시 메모리 효율이 감소할 수 있으므로 적절히 10분으로 적용

**- PAGED_TYPED_PERFORMANCE_LIST (10분)**
      PAGED_PERFORMANCE_LIST 와 동일

**- PERFORMANCE_SEAT_LIST (3초)**
      공연의 특정 스케줄에 대한 모든 좌석 예매 정보. PERFORMANCE_REMAING_SEATS_NUM 와 동일하게 캐싱 시간 적용

**- 공연 관련 캐시는 공연 정보가 추가, 삭제 되었을 때 캐시 해제 적절히 적용**

### 3. 페이징이 적용된 공연 리스트 캐시 데이터 저장시 key 값(lastPerfId)이 적용되지 않는 것 수정