### PR TITLE
[#77] 공연(좌석) 예매 기능 구현

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,37 @@
+pipeline {
+   agent any
+
+   tools {
+        maven 'MAVEN'
+        jdk 'JDK 11'
+   }
+
+   stages {
+        stage('checkout') {
+            steps {
+                checkout scm
+                echo 'git checkout success'
+            }
+        }
+
+        stage('Build') {
+            steps {
+                script {
+                    sh 'mvn clean package -DskipTests=true'
+                    echo 'build success'
+                }
+            }
+        }
+
+        stage('Unit Test') {
+            steps {
+                script {
+                    sh 'mvn surefire:test'
+                    junit '**/target/surefire-reports/TEST-*.xml'
+                }
+            }
+        }
+
+   }
+
+}

--- a/etc/show_ticketing_service.sql
+++ b/etc/show_ticketing_service.sql
@@ -103,3 +103,14 @@ CREATE TABLE pick
     FOREIGN KEY (userId)        REFERENCES user(id)         ON DELETE CASCADE,
     FOREIGN KEY (performanceId) REFERENCES performance(id)  ON DELETE CASCADE
 );
+
+CREATE TABLE reservation
+  (
+      `id`          INT UNSIGNED    NOT NULL    AUTO_INCREMENT,
+      `userId`      INT UNSIGNED    NOT NULL,
+      `seatId`      INT UNSIGNED    NOT NULL,
+      `reserveDate` DATE            NULL,
+      PRIMARY KEY (id),
+      FOREIGN KEY (userId) REFERENCES user(id)  ON DELETE CASCADE,
+      FOREIGN KEY (seatId) REFERENCES seat(id)  ON DELETE CASCADE
+  );

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
                 <configuration>
                     <excludes>
                         <exclude>**/*ControllerTest.java</exclude>
+                        <exclude>**/*ApplicationTests.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,15 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/*ControllerTest.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/show/showticketingservice/controller/ReservationController.java
+++ b/src/main/java/com/show/showticketingservice/controller/ReservationController.java
@@ -1,0 +1,28 @@
+package com.show.showticketingservice.controller;
+
+import com.show.showticketingservice.model.enumerations.AccessRoles;
+import com.show.showticketingservice.model.reservation.ReservationRequest;
+import com.show.showticketingservice.model.user.UserSession;
+import com.show.showticketingservice.service.ReservationService;
+import com.show.showticketingservice.tool.annotation.CurrentUser;
+import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reservations")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @PostMapping
+    @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
+    public void reserveSeats(@CurrentUser UserSession userSession, @RequestBody ReservationRequest reservationRequest) {
+        reservationService.reserveSeats(userSession.getUserId(), reservationRequest);
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/exception/reservation/ReserveAllowedQuantityExceededException.java
+++ b/src/main/java/com/show/showticketingservice/exception/reservation/ReserveAllowedQuantityExceededException.java
@@ -1,0 +1,9 @@
+package com.show.showticketingservice.exception.reservation;
+
+public class ReserveAllowedQuantityExceededException extends RuntimeException {
+
+    public ReserveAllowedQuantityExceededException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/exception/reservation/SeatsNotReservableException.java
+++ b/src/main/java/com/show/showticketingservice/exception/reservation/SeatsNotReservableException.java
@@ -1,0 +1,9 @@
+package com.show.showticketingservice.exception.reservation;
+
+public class SeatsNotReservableException extends RuntimeException {
+
+    public SeatsNotReservableException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/mapper/ReservationMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/ReservationMapper.java
@@ -1,0 +1,12 @@
+package com.show.showticketingservice.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ReservationMapper {
+
+    void reserveSeats(int userId, List<Integer> seatIds);
+
+}

--- a/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
@@ -15,4 +15,6 @@ public interface SeatMapper {
 
     void setSeatsReserved(List<Integer> seatIds);
 
+    int getReservableSeatsNum(int perfTimeId, List<Integer> seatIds);
+
 }

--- a/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
@@ -13,4 +13,6 @@ public interface SeatMapper {
 
     List<SeatAndPriceResponse> getPerfSeatsAndPrices(int perfTimeId);
 
+    void setSeatsReserved(List<Integer> seatIds);
+
 }

--- a/src/main/java/com/show/showticketingservice/model/reservation/ReservationRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/reservation/ReservationRequest.java
@@ -1,0 +1,16 @@
+package com.show.showticketingservice.model.reservation;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ReservationRequest {
+
+    private final int perfTimeId;
+
+    private final List<Integer> seatIds;
+
+}

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.service;
 
+import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
 import com.show.showticketingservice.mapper.ReservationMapper;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ReservationService {
 
+    private final static int MAX_RESERVATION_QUANTITY = 4;
+
     private final ReservationMapper reservationMapper;
 
     private final PerformanceService performanceService;
@@ -18,6 +21,9 @@ public class ReservationService {
 
     @Transactional
     public void reserveSeats(int userId, ReservationRequest reservationRequest) {
+        if (reservationRequest.getSeatIds().size() > MAX_RESERVATION_QUANTITY)
+            throw new ReserveAllowedQuantityExceededException("최대 예매 가능 좌석 수는 4자리 입니다.");
+
         performanceService.checkPerfTimeIdExists(reservationRequest.getPerfTimeId());
         seatService.setSeatsReserved(reservationRequest.getSeatIds());
         reservationMapper.reserveSeats(userId, reservationRequest.getSeatIds());

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -1,0 +1,26 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.mapper.ReservationMapper;
+import com.show.showticketingservice.model.reservation.ReservationRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationMapper reservationMapper;
+
+    private final PerformanceService performanceService;
+
+    private final SeatService seatService;
+
+    @Transactional
+    public void reserveSeats(int userId, ReservationRequest reservationRequest) {
+        performanceService.checkPerfTimeIdExists(reservationRequest.getPerfTimeId());
+        seatService.setSeatsReserved(reservationRequest.getSeatIds());
+        reservationMapper.reserveSeats(userId, reservationRequest.getSeatIds());
+    }
+
+}

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -1,11 +1,14 @@
 package com.show.showticketingservice.service;
 
 import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
+import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
 import com.show.showticketingservice.mapper.ReservationMapper;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +28,15 @@ public class ReservationService {
             throw new ReserveAllowedQuantityExceededException("최대 예매 가능 좌석 수는 4자리 입니다.");
 
         performanceService.checkPerfTimeIdExists(reservationRequest.getPerfTimeId());
+        checkSeatsReservable(reservationRequest.getPerfTimeId(), reservationRequest.getSeatIds());
+
         seatService.setSeatsReserved(reservationRequest.getSeatIds());
         reservationMapper.reserveSeats(userId, reservationRequest.getSeatIds());
+    }
+
+    private void checkSeatsReservable(int perfTimeId, List<Integer> seatIds) {
+        if (seatIds.size() != seatService.getReservableSeatsNum(perfTimeId, seatIds))
+            throw new SeatsNotReservableException("이미 예매되었거나 다른 스케줄 또는 유효하지 않은 좌석이 존재합니다.");
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -4,7 +4,6 @@ import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantit
 import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
 import com.show.showticketingservice.mapper.ReservationMapper;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,10 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 public class ReservationService {
 
-    private static int MAX_RESERVATION_QUANTITY;
+    private final int MAX_RESERVATION_QUANTITY;
 
     private final ReservationMapper reservationMapper;
 
@@ -23,9 +21,14 @@ public class ReservationService {
 
     private final SeatService seatService;
 
-    @Value("${service.value.max-reservation-quantity}")
-    public void setMaxReservationQuantity(int quantity) {
-        ReservationService.MAX_RESERVATION_QUANTITY = quantity;
+    public ReservationService(@Value("${service.value.max-reservation-quantity}") int quantity,
+                              ReservationMapper reservationMapper,
+                              PerformanceService performanceService,
+                              SeatService seatService) {
+        this.MAX_RESERVATION_QUANTITY = quantity;
+        this.reservationMapper = reservationMapper;
+        this.performanceService = performanceService;
+        this.seatService = seatService;
     }
 
     @Transactional

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Service
 public class ReservationService {
 
-    private final int MAX_RESERVATION_QUANTITY;
+    private final int maxReservationQuantity;
 
     private final ReservationMapper reservationMapper;
 
@@ -25,7 +25,7 @@ public class ReservationService {
                               ReservationMapper reservationMapper,
                               PerformanceService performanceService,
                               SeatService seatService) {
-        this.MAX_RESERVATION_QUANTITY = quantity;
+        this.maxReservationQuantity = quantity;
         this.reservationMapper = reservationMapper;
         this.performanceService = performanceService;
         this.seatService = seatService;
@@ -33,7 +33,7 @@ public class ReservationService {
 
     @Transactional
     public void reserveSeats(int userId, ReservationRequest reservationRequest) {
-        if (reservationRequest.getSeatIds().size() > MAX_RESERVATION_QUANTITY)
+        if (reservationRequest.getSeatIds().size() > maxReservationQuantity)
             throw new ReserveAllowedQuantityExceededException("최대 예매 가능 좌석 수는 4자리 입니다.");
 
         performanceService.checkPerfTimeIdExists(reservationRequest.getPerfTimeId());

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -5,6 +5,7 @@ import com.show.showticketingservice.exception.reservation.SeatsNotReservableExc
 import com.show.showticketingservice.mapper.ReservationMapper;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,13 +15,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ReservationService {
 
-    private final static int MAX_RESERVATION_QUANTITY = 4;
+    private static int MAX_RESERVATION_QUANTITY;
 
     private final ReservationMapper reservationMapper;
 
     private final PerformanceService performanceService;
 
     private final SeatService seatService;
+
+    @Value("${service.value.max-reservation-quantity}")
+    public void setMaxReservationQuantity(int quantity) {
+        ReservationService.MAX_RESERVATION_QUANTITY = quantity;
+    }
 
     @Transactional
     public void reserveSeats(int userId, ReservationRequest reservationRequest) {

--- a/src/main/java/com/show/showticketingservice/service/SeatService.java
+++ b/src/main/java/com/show/showticketingservice/service/SeatService.java
@@ -25,4 +25,9 @@ public class SeatService {
     public void setSeatsReserved(List<Integer> seatIds) {
         seatMapper.setSeatsReserved(seatIds);
     }
+
+    public int getReservableSeatsNum(int perfTimeId, List<Integer> seatIds) {
+        return seatMapper.getReservableSeatsNum(perfTimeId, seatIds);
+    }
+
 }

--- a/src/main/java/com/show/showticketingservice/service/SeatService.java
+++ b/src/main/java/com/show/showticketingservice/service/SeatService.java
@@ -22,4 +22,7 @@ public class SeatService {
         return seatMapper.getPerfSeatsAndPrices(perfTimeId);
     }
 
+    public void setSeatsReserved(List<Integer> seatIds) {
+        seatMapper.setSeatsReserved(seatIds);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
@@ -1,6 +1,7 @@
 package com.show.showticketingservice.tool.advice;
 
 import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
+import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,13 @@ public class ReservationExceptionAdvice {
     @ExceptionHandler(ReserveAllowedQuantityExceededException.class)
     public ResponseEntity<ExceptionResponse> ReserveAllowedQuantityExceededException(final ReserveAllowedQuantityExceededException e, WebRequest request) {
         log.error("reservation failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(SeatsNotReservableException.class)
+    public ResponseEntity<ExceptionResponse> seatsNotReservableException(final SeatsNotReservableException e, WebRequest request) {
+        log.error("reservation failed - request reservation with invalid seats", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
@@ -1,0 +1,23 @@
+package com.show.showticketingservice.tool.advice;
+
+import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
+import com.show.showticketingservice.model.responses.ExceptionResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@Slf4j
+@RestControllerAdvice
+public class ReservationExceptionAdvice {
+
+    @ExceptionHandler(ReserveAllowedQuantityExceededException.class)
+    public ResponseEntity<ExceptionResponse> ReserveAllowedQuantityExceededException(final ReserveAllowedQuantityExceededException e, WebRequest request) {
+        log.error("reservation failed", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -23,3 +23,6 @@ spring.servlet.multipart.enabled=true
 spring.servlet.multipart.location=files/performanceImages
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+# Business Setting Values
+service.value.max-reservation-quantity=4

--- a/src/main/resources/mybatis/mappers/ReservationMapper.xml
+++ b/src/main/resources/mybatis/mappers/ReservationMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.show.showticketingservice.mapper.ReservationMapper">
+
+    <insert id="reserveSeats" parameterType="java.util.List">
+        INSERT INTO reservation(userId, seatId, reserveDate)
+        VALUES
+        <foreach collection="seatIds" item="seatId" separator=",">
+            ( #{userId}, #{seatId}, DATE(NOW()) )
+        </foreach>
+    </insert>
+
+</mapper>

--- a/src/main/resources/mybatis/mappers/SeatMapper.xml
+++ b/src/main/resources/mybatis/mappers/SeatMapper.xml
@@ -26,4 +26,13 @@
         WHERE s.perfTimeId = #{perfTimeId}
     </select>
 
+    <update id="setSeatsReserved" parameterType="java.util.List">
+        UPDATE seat
+        SET reserved = TRUE
+        WHERE id IN
+        <foreach collection="seatIds" item="seatId" open="(" close=")" separator=", ">
+            #{seatId}
+        </foreach>
+    </update>
+
 </mapper>

--- a/src/main/resources/mybatis/mappers/SeatMapper.xml
+++ b/src/main/resources/mybatis/mappers/SeatMapper.xml
@@ -35,4 +35,15 @@
         </foreach>
     </update>
 
+    <select id="getReservableSeatsNum" parameterType="map" resultType="int">
+        SELECT COUNT(*)
+        FROM seat
+        WHERE id IN
+        <foreach collection="seatIds" item="seatId" open="(" close=")" separator=", ">
+            #{seatId}
+        </foreach>
+        AND perfTimeId = #{perfTimeId}
+        AND reserved = FALSE
+    </select>
+
 </mapper>

--- a/src/test/java/com/show/showticketingservice/service/PickServiceTest.java
+++ b/src/test/java/com/show/showticketingservice/service/PickServiceTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-
 @ExtendWith(MockitoExtension.class)
 class PickServiceTest {
 

--- a/src/test/java/com/show/showticketingservice/service/ReservationServiceTest.java
+++ b/src/test/java/com/show/showticketingservice/service/ReservationServiceTest.java
@@ -8,7 +8,6 @@ import com.show.showticketingservice.model.reservation.ReservationRequest;
 import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -22,6 +21,8 @@ import static org.mockito.Mockito.times;
 @ExtendWith(MockitoExtension.class)
 class ReservationServiceTest {
 
+    private int max_reservation_quantity = 4;
+
     @Mock
     private ReservationMapper reservationMapper;
 
@@ -31,12 +32,11 @@ class ReservationServiceTest {
     @Mock
     private SeatService seatService;
 
-    @InjectMocks
     private ReservationService reservationService;
 
     @BeforeEach
     public void init() {
-        reservationService.setMaxReservationQuantity(4);
+        reservationService = new ReservationService(max_reservation_quantity, reservationMapper, performanceService,seatService);
     }
 
     @Nested
@@ -55,7 +55,7 @@ class ReservationServiceTest {
         }
 
         @Test
-        @DisplayName("[예매 좌석 수: 2 / 성공] 최대 예매 가능 좌석 수(4개)를 이내로 예매할 시 예매 성공")
+        @DisplayName("[예매 요청 좌석 수 검사 1] 최대 예매 가능 좌석 수(4개) 이내로 예매 요청 할 경우 예매 성공 (예매 요청 좌석 수: 2) ")
         public void multipleSeatsReservation() {
             insertSeatNums(2);
             ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
@@ -70,7 +70,7 @@ class ReservationServiceTest {
         }
 
         @Test
-        @DisplayName("[예매 좌석 수: 5 / 실패] 최대 예매 가능 좌석 수(4개)를 초과하여 예매할 경우")
+        @DisplayName("[예매 요청 좌석 수 검사 2] 최대 예매 가능 좌석 수(4개)를 초과하여 예매 요청할 경우 예매 실패 (예매 요청 좌석 수: 5) ")
         public void SingleSeatReservation() {
             insertSeatNums(5);
             ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
@@ -85,7 +85,7 @@ class ReservationServiceTest {
         }
 
         @Test
-        @DisplayName("[공연 스케줄 유효 검사 / 실패] 존재하지 않는 공연 스케줄에 대해 예매 요청한 경우")
+        @DisplayName("[공연 스케줄 유효 검사] 존재하지 않는 공연 스케줄에 대해 예매 요청한 경우 예매 실패")
         public void reserveWithNoExistingPerfTime() {
             insertSeatNums(2);
             ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
@@ -102,7 +102,7 @@ class ReservationServiceTest {
         }
 
         @Test
-        @DisplayName("[예매 요청 좌석 유효 검사 1 / 실패] 존재하지 않는 좌석을 포함하여 예매 요청한 경우")
+        @DisplayName("[예매 요청 좌석 유효 검사 1] 존재하지 않는 좌석을 포함하여 예매 요청한 경우 예매 실패")
         public void reserveWithNoExistingSeat() {
 
             List<Seat> seatDB = initSeatDB();
@@ -125,7 +125,7 @@ class ReservationServiceTest {
         }
 
         @Test
-        @DisplayName("[예매 요청 좌석 유효 검사 2 / 실패] 이미 예매 된 좌석을 포함하여 예매 요청한 경우")
+        @DisplayName("[예매 요청 좌석 유효 검사 2] 이미 예매 된 좌석을 포함하여 예매 요청한 경우 예매 실패")
         public void reserveWithAlreadyReservedSeat() {
             List<Seat> seatDB = initSeatDB();
 
@@ -147,7 +147,7 @@ class ReservationServiceTest {
         }
 
         @Test
-        @DisplayName("[예매 요청 좌석 유효 검사 3 / 실패] 스케줄(또는 공연)이 다른 좌석이 포함된 경우")
+        @DisplayName("[예매 요청 좌석 유효 검사 3] 스케줄(또는 공연)이 다른 좌석을 포함하여 예매 요청한 경우 예매 실패")
         public void reserveWithDifferentPerfTimeSeat() {
             List<Seat> seatDB = initSeatDB();
 

--- a/src/test/java/com/show/showticketingservice/service/ReservationServiceTest.java
+++ b/src/test/java/com/show/showticketingservice/service/ReservationServiceTest.java
@@ -1,0 +1,205 @@
+package com.show.showticketingservice.service;
+
+import com.show.showticketingservice.exception.performance.PerformanceTimeNotExistsException;
+import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
+import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
+import com.show.showticketingservice.mapper.ReservationMapper;
+import com.show.showticketingservice.model.reservation.ReservationRequest;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @Mock
+    private ReservationMapper reservationMapper;
+
+    @Mock
+    private PerformanceService performanceService;
+
+    @Mock
+    private SeatService seatService;
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Nested
+    @DisplayName("[좌석 예매 테스트]")
+    class MakeReservationTest {
+
+        int userId = 1;
+
+        int perfTimeId = 1;
+
+        private List<Integer> seatNums = new ArrayList<>();
+
+        private List<Seat> seatDB = new ArrayList<>();
+
+        @AfterEach
+        public void clearSeatNums() {
+            seatNums.clear();
+        }
+
+        @Test
+        @DisplayName("[예매 좌석 수: 2 / 성공] 최대 예매 가능 좌석 수(4개)를 이내로 예매할 시 예매 성공")
+        public void multipleSeatsReservation() {
+            insertSeatNums(2);
+            ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
+
+            given(seatService.getReservableSeatsNum(request.getPerfTimeId(), request.getSeatIds())).willReturn(2);
+
+            reservationService.reserveSeats(userId, request);
+
+            verify(performanceService, times(1)).checkPerfTimeIdExists(request.getPerfTimeId());
+            verify(seatService, times(1)).setSeatsReserved(request.getSeatIds());
+            verify(reservationMapper, times(1)).reserveSeats(userId, request.getSeatIds());
+        }
+
+        @Test
+        @DisplayName("[예매 좌석 수: 5 / 실패] 최대 예매 가능 좌석 수(4개)를 초과하여 예매할 경우")
+        public void SingleSeatReservation() {
+            insertSeatNums(5);
+            ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
+
+            assertThrows(ReserveAllowedQuantityExceededException.class, () -> {
+                reservationService.reserveSeats(userId, request);
+            });
+
+            verify(performanceService, times(0)).checkPerfTimeIdExists(request.getPerfTimeId());
+            verify(seatService, times(0)).setSeatsReserved(request.getSeatIds());
+            verify(reservationMapper, times(0)).reserveSeats(userId, request.getSeatIds());
+        }
+
+        @Test
+        @DisplayName("[공연 스케줄 유효 검사 / 실패] 존재하지 않는 공연 스케줄에 대해 예매 요청한 경우")
+        public void reserveWithNoExistingPerfTime() {
+            insertSeatNums(2);
+            ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
+
+            willThrow(PerformanceTimeNotExistsException.class).given(performanceService).checkPerfTimeIdExists(request.getPerfTimeId());
+
+            assertThrows(PerformanceTimeNotExistsException.class, () -> {
+                reservationService.reserveSeats(userId, request);
+            });
+
+            verify(performanceService, times(1)).checkPerfTimeIdExists(request.getPerfTimeId());
+            verify(seatService, times(0)).setSeatsReserved(request.getSeatIds());
+            verify(reservationMapper, times(0)).reserveSeats(userId, request.getSeatIds());
+        }
+
+        @Test
+        @DisplayName("[예매 요청 좌석 유효 검사 1 / 실패] 존재하지 않는 좌석을 포함하여 예매 요청한 경우")
+        public void reserveWithNoExistingSeat() {
+
+            List<Seat> seatDB = initSeatDB();
+
+            seatNums.add(1); // 정상 좌석
+            seatNums.add(4); // 존재하지 않는 좌석
+
+            ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
+
+            willDoNothing().given(performanceService).checkPerfTimeIdExists(request.getPerfTimeId());
+            given(seatService.getReservableSeatsNum(request.getPerfTimeId(), request.getSeatIds())).willReturn(getValidSeatNum(seatDB, seatNums, perfTimeId));
+
+            assertThrows(SeatsNotReservableException.class, () -> {
+                reservationService.reserveSeats(userId, request);
+            });
+
+            verify(performanceService, times(1)).checkPerfTimeIdExists(request.getPerfTimeId());
+            verify(seatService, times(0)).setSeatsReserved(request.getSeatIds());
+            verify(reservationMapper, times(0)).reserveSeats(userId, request.getSeatIds());
+        }
+
+        @Test
+        @DisplayName("[예매 요청 좌석 유효 검사 2 / 실패] 이미 예매 된 좌석을 포함하여 예매 요청한 경우")
+        public void reserveWithAlreadyReservedSeat() {
+            List<Seat> seatDB = initSeatDB();
+
+            seatNums.add(1); // 정상 좌석
+            seatNums.add(2); // 이미 예매된 좌석
+
+            ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
+
+            willDoNothing().given(performanceService).checkPerfTimeIdExists(request.getPerfTimeId());
+            given(seatService.getReservableSeatsNum(request.getPerfTimeId(), request.getSeatIds())).willReturn(getValidSeatNum(seatDB, seatNums, perfTimeId));
+
+            assertThrows(SeatsNotReservableException.class, () -> {
+                reservationService.reserveSeats(userId, request);
+            });
+
+            verify(performanceService, times(1)).checkPerfTimeIdExists(request.getPerfTimeId());
+            verify(seatService, times(0)).setSeatsReserved(request.getSeatIds());
+            verify(reservationMapper, times(0)).reserveSeats(userId, request.getSeatIds());
+        }
+
+        @Test
+        @DisplayName("[예매 요청 좌석 유효 검사 3 / 실패] 스케줄(또는 공연)이 다른 좌석이 포함된 경우")
+        public void reserveWithDifferentPerfTimeSeat() {
+            List<Seat> seatDB = initSeatDB();
+
+            seatNums.add(1); // 정상 좌석
+            seatNums.add(3); // 공연 스케줄이 다른 좌석
+
+            ReservationRequest request = new ReservationRequest(perfTimeId, seatNums);
+
+            willDoNothing().given(performanceService).checkPerfTimeIdExists(request.getPerfTimeId());
+            given(seatService.getReservableSeatsNum(request.getPerfTimeId(), request.getSeatIds())).willReturn(getValidSeatNum(seatDB, seatNums, perfTimeId));
+
+            assertThrows(SeatsNotReservableException.class, () -> {
+                reservationService.reserveSeats(userId, request);
+            });
+
+            verify(performanceService, times(1)).checkPerfTimeIdExists(request.getPerfTimeId());
+            verify(seatService, times(0)).setSeatsReserved(request.getSeatIds());
+            verify(reservationMapper, times(0)).reserveSeats(userId, request.getSeatIds());
+        }
+
+        public void insertSeatNums(int count) {
+            for (int seat = 1; seat <= count; seat++) {
+                seatNums.add(seat);
+            }
+        }
+
+        public List<Seat> initSeatDB() {
+            List<Seat> seatDB = new ArrayList<>();
+
+            seatDB.add(new Seat(1, perfTimeId, false));
+            seatDB.add(new Seat(2, perfTimeId, true));
+            seatDB.add(new Seat(3, 2, false));
+
+            return seatDB;
+        }
+
+        public int getValidSeatNum(List<Seat> seatDB, List<Integer> seatNums, int perfTimeId) {
+            return (int) seatDB.stream()
+                    .filter(s -> !s.reserved)
+                    .filter(s -> seatNums.contains(s.seatId))
+                    .filter(s -> s.perfTimeId == perfTimeId)
+                    .count();
+        }
+
+        // 예매 테스트를 위한 Seat Class
+        @AllArgsConstructor
+        class Seat {
+            int seatId;
+            int perfTimeId;
+            boolean reserved;
+        }
+
+    }
+
+}

--- a/src/test/java/com/show/showticketingservice/service/ReservationServiceTest.java
+++ b/src/test/java/com/show/showticketingservice/service/ReservationServiceTest.java
@@ -6,10 +6,7 @@ import com.show.showticketingservice.exception.reservation.SeatsNotReservableExc
 import com.show.showticketingservice.mapper.ReservationMapper;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
 import lombok.AllArgsConstructor;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -37,6 +34,11 @@ class ReservationServiceTest {
     @InjectMocks
     private ReservationService reservationService;
 
+    @BeforeEach
+    public void init() {
+        reservationService.setMaxReservationQuantity(4);
+    }
+
     @Nested
     @DisplayName("[좌석 예매 테스트]")
     class MakeReservationTest {
@@ -46,8 +48,6 @@ class ReservationServiceTest {
         int perfTimeId = 1;
 
         private List<Integer> seatNums = new ArrayList<>();
-
-        private List<Seat> seatDB = new ArrayList<>();
 
         @AfterEach
         public void clearSeatNums() {


### PR DESCRIPTION
#77 

## 개요
- **서비스 시나리오:**
    1. 예매하고자 하는 공연에 대한 특정 스케줄의 전체 좌석 정보를 먼저 조회.
    2. 조회된 좌석 정보에는 좌석 위치와 가격, 예매 여부가 포함
    3. 원하는 좌석을 선택(다중 선택 가능)하여 예매 요청
- **특이사항:**
    - 한번에 최대 예매 가능 좌석수는 4자리
    - 다른 스케줄 또는 공연의 좌석 동시 예매 불가능
    - *결제 시스템 연동*은 추후에 적용 예정
- *일반 회원 기능*


## Progress

- [x] 기능 구현
- [x] 테스트 코드

---
### 기능 구현
- **DB에 예매(reservation) 테이블 생성**
    - 속성: id, userId, seatId, reserveDate(예매날짜)

<br>

- **공연 예매 기능**
    1. ***ReservationRequest* 객체를 전달받아 예매 요청**
        - 인스턴스: perfTimeId(공연 스케줄 id), seatIds(예매할 좌석id 리스트)
    2. **공연 예매 처리 전 공연 시간이 존재하는지 확인**
    3. **예매 가능한 좌석 정보인지 확인**(checkSeatsReservable())
        - 체크 항목: 
            - 유효한 좌석id
            - 예매 가능 여부
            - 동일한 스케줄
        - 요청을 보낸 좌석수와 DB에서 예매 가능한 좌석수를 비교하여 판단
    4. **좌석(seat) 데이터에 예매상태(reserved) true로 변경** (setSeatsReserved())
    5. **예매(reservation) 테이블에 예매 데이터 추가** (reserveSeats())

<br>

- 트랜잭션 적용

<br> 

### 예매가 되지 않는 상황
- **최대 예매 가능 좌석수(4)를 초과**하여 요청한 경우
- 요청 데이터의 **공연 스케줄이 존재하지 않는** 경우
- **존재하지 않는 좌석**이 포함된 경우
- **이미 예매된 좌석**이 포함된 경우
- 요청한 좌석이 모두 **동일한 스케줄이 아닌 경우**