### PR TITLE
[#124] 프로젝트 JDK 버전 변경

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
    tools {
         maven 'MAVEN'
-        jdk 'JDK 11'
+        jdk 'JDK 1.8'
    }
 
    stages {

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <description>show ticketing service project for Spring Boot</description>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/show/showticketingservice/exception/authentication/UserAlreadyLoggedInException.java
+++ b/src/main/java/com/show/showticketingservice/exception/authentication/UserAlreadyLoggedInException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.authentication;
+
+public class UserAlreadyLoggedInException extends RuntimeException {
+
+    public UserAlreadyLoggedInException() {
+        super("이미 로그인되어 있습니다.");
+    }
+}

--- a/src/main/java/com/show/showticketingservice/service/PerformanceService.java
+++ b/src/main/java/com/show/showticketingservice/service/PerformanceService.java
@@ -377,7 +377,7 @@ public class PerformanceService {
     }
 
     public List<PerformanceResponse> getPerformancesByKeyword(String keyword, PerformancePagingCriteria performancePagingCriteria) {
-        if (keyword == null || keyword.isBlank())
+        if (keyword == null || keyword.trim().isEmpty())
             throw new NoKeywordException();
 
         return performanceMapper.getPerformancesByKeyword(keyword, performancePagingCriteria);

--- a/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
+++ b/src/main/java/com/show/showticketingservice/service/SessionLoginService.java
@@ -1,10 +1,10 @@
 package com.show.showticketingservice.service;
 
+import com.show.showticketingservice.exception.authentication.UserAlreadyLoggedInException;
 import com.show.showticketingservice.model.enumerations.UserType;
 import com.show.showticketingservice.model.user.UserLoginRequest;
 import com.show.showticketingservice.model.user.UserResponse;
 import com.show.showticketingservice.model.user.UserSession;
-import com.sun.jdi.request.DuplicateRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -24,7 +24,7 @@ public class SessionLoginService implements LoginService {
     public UserType login(UserLoginRequest userLoginRequest) {
 
         if (httpSession.getAttribute(USER) != null) {
-            throw new DuplicateRequestException("이미 로그인 된 상태입니다.");
+            throw new UserAlreadyLoggedInException();
         }
 
         UserResponse userResponse = userService.getUser(userLoginRequest.getUserId(), userLoginRequest.getPassword());

--- a/src/main/java/com/show/showticketingservice/tool/advice/AuthenticationExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/AuthenticationExceptionAdvice.java
@@ -2,7 +2,6 @@ package com.show.showticketingservice.tool.advice;
 
 import com.show.showticketingservice.exception.authentication.*;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
-import com.sun.jdi.request.DuplicateRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -28,9 +27,9 @@ public class AuthenticationExceptionAdvice {
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(DuplicateRequestException.class)
-    public ResponseEntity<ExceptionResponse> alreadyLoginException(final DuplicateRequestException e, WebRequest request) {
-        log.error("login Failed", e);
+    @ExceptionHandler(UserAlreadyLoggedInException.class)
+    public ResponseEntity<ExceptionResponse> alreadyLoginException(final UserAlreadyLoggedInException e, WebRequest request) {
+        log.error("User has Already logged in", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.CONFLICT);
     }


### PR DESCRIPTION
#124 

---

**Java 11** to **Java 8**

---

## 변경 이유:
- 프로젝트 관련 기타 프로그램과의 연동을 위함 (NCP에서 제공하는 pinoint 1.7.3은 Java 11을 지원하지 않음 )
- Docker를 적용하기 전이므로 버전의 통일이 필요
- 현재 사용 중인 java 11의 스펙을 온전히 사용하지 않으므로 현재 버전을 고수할 이유가 없음

## 작업
### 프로젝트의 JDK 버전 변경에 따른 수정 사항
1. **중복 로그인 시도에 대한 예외 처리** (SessionLoginService)
    - 기존: `DuplicateRequestException` (java 8에서 지원되지 않음)
    - 수정: `UserAlreadyLoggedInException` 클래스 생성 & 적용
2. **공연 검색 중 검색 키워드가 빈 문자열인지 확인** (PerformanceService)
    - 기존: String의 `isBlank()` 메소드 사용 (java 11 부터 사용 가능)
    - 수정: String의 `trim()` 메소드로 앞뒤 공백을 제거 후 `isEmpty()` 메소드로 빈 문자열인지 확인
3. **Jenkins pipeline 수행 JDK 버전 변경**