### PR TITLE
[#78] 예매 취소 기능 구현

### DIFF
--- a/src/main/java/com/show/showticketingservice/controller/ReservationController.java
+++ b/src/main/java/com/show/showticketingservice/controller/ReservationController.java
@@ -1,16 +1,16 @@
 package com.show.showticketingservice.controller;
 
 import com.show.showticketingservice.model.enumerations.AccessRoles;
+import com.show.showticketingservice.model.reservation.ReservationInfoToCancelRequest;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
 import com.show.showticketingservice.model.user.UserSession;
 import com.show.showticketingservice.service.ReservationService;
 import com.show.showticketingservice.tool.annotation.CurrentUser;
 import com.show.showticketingservice.tool.annotation.UserAuthenticationNecessary;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +23,12 @@ public class ReservationController {
     @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
     public void reserveSeats(@CurrentUser UserSession userSession, @RequestBody ReservationRequest reservationRequest) {
         reservationService.reserveSeats(userSession.getUserId(), reservationRequest);
+    }
+
+    @DeleteMapping
+    @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
+    public void cancelReservedSeats(@RequestBody @Valid ReservationInfoToCancelRequest reservationInfoToCancelRequest) {
+        reservationService.cancelReservedSeats(reservationInfoToCancelRequest);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/controller/ReservationController.java
+++ b/src/main/java/com/show/showticketingservice/controller/ReservationController.java
@@ -27,8 +27,8 @@ public class ReservationController {
 
     @DeleteMapping
     @UserAuthenticationNecessary(role = AccessRoles.GENERAL)
-    public void cancelReservedSeats(@RequestBody @Valid ReservationInfoToCancelRequest reservationInfoToCancelRequest) {
-        reservationService.cancelReservedSeats(reservationInfoToCancelRequest);
+    public void cancelSeats(@CurrentUser UserSession userSession, @RequestBody @Valid ReservationInfoToCancelRequest reservationInfoToCancelRequest) {
+        reservationService.cancelSeats(userSession.getUserId(), reservationInfoToCancelRequest);
     }
 
 }

--- a/src/main/java/com/show/showticketingservice/exception/reservation/ReservationIdNotExistsException.java
+++ b/src/main/java/com/show/showticketingservice/exception/reservation/ReservationIdNotExistsException.java
@@ -1,8 +1,0 @@
-package com.show.showticketingservice.exception.reservation;
-
-public class ReservationIdNotExistsException extends RuntimeException {
-
-    public ReservationIdNotExistsException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/show/showticketingservice/exception/reservation/ReservationIdNotExistsException.java
+++ b/src/main/java/com/show/showticketingservice/exception/reservation/ReservationIdNotExistsException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.reservation;
+
+public class ReservationIdNotExistsException extends RuntimeException {
+
+    public ReservationIdNotExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/show/showticketingservice/exception/reservation/ReservationNumNotExistsException.java
+++ b/src/main/java/com/show/showticketingservice/exception/reservation/ReservationNumNotExistsException.java
@@ -1,0 +1,8 @@
+package com.show.showticketingservice.exception.reservation;
+
+public class ReservationNumNotExistsException extends RuntimeException {
+
+    public ReservationNumNotExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/show/showticketingservice/mapper/ReservationMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/ReservationMapper.java
@@ -1,6 +1,8 @@
 package com.show.showticketingservice.mapper;
 
+import com.show.showticketingservice.model.reservation.ReservationInfoToCancelRequest;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.List;
 
@@ -9,7 +11,7 @@ public interface ReservationMapper {
 
     void reserveSeats(int userId, List<Integer> seatIds);
 
-    void cancelReservedSeats(List<Integer> reservationIds);
+    void cancelSeats(List<Integer> reservationIds);
 
-    int getReservedSeatsNum(List<Integer> reservationIds);
+    int getSeatNumToCancel(int userId, @Param("reservationInfo") ReservationInfoToCancelRequest reservationInfoToCancelRequest);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/ReservationMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/ReservationMapper.java
@@ -9,4 +9,7 @@ public interface ReservationMapper {
 
     void reserveSeats(int userId, List<Integer> seatIds);
 
+    void cancelReservedSeats(List<Integer> reservationIds);
+
+    int getReservedSeatsNum(List<Integer> reservationIds);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
@@ -17,5 +17,5 @@ public interface SeatMapper {
 
     int getReservableSeatsNum(int perfTimeId, List<Integer> seatIds);
 
-    void setReservedSeatsCancel(List<Integer> reservationIds);
+    void setSeatsCancel(List<Integer> reservationIds);
 }

--- a/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
+++ b/src/main/java/com/show/showticketingservice/mapper/SeatMapper.java
@@ -17,4 +17,5 @@ public interface SeatMapper {
 
     int getReservableSeatsNum(int perfTimeId, List<Integer> seatIds);
 
+    void setReservedSeatsCancel(List<Integer> reservationIds);
 }

--- a/src/main/java/com/show/showticketingservice/model/reservation/ReservationInfoToCancelRequest.java
+++ b/src/main/java/com/show/showticketingservice/model/reservation/ReservationInfoToCancelRequest.java
@@ -1,0 +1,23 @@
+package com.show.showticketingservice.model.reservation;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ReservationInfoToCancelRequest {
+
+    @NotNull(message = "공연 시간 id를 입력해 주세요.")
+    private final int perfTimeId;
+
+    @NotNull(message = "공연 id를 입력해 주세요.")
+    public final int performanceId;
+
+    @Size(min = 1, message = "예약한 id를 입력해 주세요.")
+    @NotNull(message = "예약한 id를 입력해 주세요.")
+    private final List<Integer> reservationIds;
+}

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -1,10 +1,16 @@
 package com.show.showticketingservice.service;
 
+import com.show.showticketingservice.exception.reservation.ReservationIdNotExistsException;
 import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
 import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
 import com.show.showticketingservice.mapper.ReservationMapper;
+import com.show.showticketingservice.model.reservation.ReservationInfoToCancelRequest;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
+import com.show.showticketingservice.tool.constants.CacheConstant;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,4 +54,25 @@ public class ReservationService {
             throw new SeatsNotReservableException("이미 예매되었거나 다른 스케줄 또는 유효하지 않은 좌석이 존재합니다.");
     }
 
+    @Caching(evict = {
+            @CacheEvict(cacheNames = CacheConstant.PERFORMANCE_SEAT_LIST, key = "#reservationInfoToCancelRequest.perfTimeId"),
+            @CacheEvict(cacheNames = CacheConstant.PERFORMANCE_REMAINING_SEAT_NUM, key = "#reservationInfoToCancelRequest.performanceId + #reservationInfoToCancelRequest.perfTimeId")
+    })
+    @Transactional
+    public void cancelReservedSeats(ReservationInfoToCancelRequest reservationInfoToCancelRequest) {
+        performanceService.checkValidPerformanceId(reservationInfoToCancelRequest.getPerformanceId());
+        performanceService.checkPerfTimeIdExists(reservationInfoToCancelRequest.getPerfTimeId());
+
+        checkReservationIdExists(reservationInfoToCancelRequest.getReservationIds());
+
+        seatService.setReservedSeatsCancel(reservationInfoToCancelRequest.getReservationIds());
+
+        reservationMapper.cancelReservedSeats(reservationInfoToCancelRequest.getReservationIds());
+    }
+
+    private void checkReservationIdExists(List<Integer> reservationIds ) {
+        if(reservationIds.size() != reservationMapper.getReservedSeatsNum(reservationIds)) {
+            throw new ReservationIdNotExistsException("예약한 id가 존재하지 않습니다.");
+        }
+    }
 }

--- a/src/main/java/com/show/showticketingservice/service/ReservationService.java
+++ b/src/main/java/com/show/showticketingservice/service/ReservationService.java
@@ -1,15 +1,15 @@
 package com.show.showticketingservice.service;
 
-import com.show.showticketingservice.exception.reservation.ReservationIdNotExistsException;
+import com.show.showticketingservice.exception.reservation.ReservationNumNotExistsException;
 import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
 import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
 import com.show.showticketingservice.mapper.ReservationMapper;
 import com.show.showticketingservice.model.reservation.ReservationInfoToCancelRequest;
 import com.show.showticketingservice.model.reservation.ReservationRequest;
+import com.show.showticketingservice.model.user.UserSession;
 import com.show.showticketingservice.tool.constants.CacheConstant;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -59,20 +59,18 @@ public class ReservationService {
             @CacheEvict(cacheNames = CacheConstant.PERFORMANCE_REMAINING_SEAT_NUM, key = "#reservationInfoToCancelRequest.performanceId + #reservationInfoToCancelRequest.perfTimeId")
     })
     @Transactional
-    public void cancelReservedSeats(ReservationInfoToCancelRequest reservationInfoToCancelRequest) {
-        performanceService.checkValidPerformanceId(reservationInfoToCancelRequest.getPerformanceId());
-        performanceService.checkPerfTimeIdExists(reservationInfoToCancelRequest.getPerfTimeId());
+    public void cancelSeats(int userId, ReservationInfoToCancelRequest reservationInfoToCancelRequest) {
 
-        checkReservationIdExists(reservationInfoToCancelRequest.getReservationIds());
+        checkReservationIdExists(userId, reservationInfoToCancelRequest);
 
-        seatService.setReservedSeatsCancel(reservationInfoToCancelRequest.getReservationIds());
+        seatService.setSeatsCancel(reservationInfoToCancelRequest.getReservationIds());
 
-        reservationMapper.cancelReservedSeats(reservationInfoToCancelRequest.getReservationIds());
+        reservationMapper.cancelSeats(reservationInfoToCancelRequest.getReservationIds());
     }
 
-    private void checkReservationIdExists(List<Integer> reservationIds ) {
-        if(reservationIds.size() != reservationMapper.getReservedSeatsNum(reservationIds)) {
-            throw new ReservationIdNotExistsException("예약한 id가 존재하지 않습니다.");
+    private void checkReservationIdExists(int userId, ReservationInfoToCancelRequest reservationInfoToCancelRequest ) {
+        if(reservationInfoToCancelRequest.getReservationIds().size() != reservationMapper.getSeatNumToCancel(userId, reservationInfoToCancelRequest)) {
+            throw new ReservationNumNotExistsException("예매하신 예약 id가 존재하지 않거나 공연 정보와 관련된 예약 id 존재하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/SeatService.java
+++ b/src/main/java/com/show/showticketingservice/service/SeatService.java
@@ -30,7 +30,7 @@ public class SeatService {
         return seatMapper.getReservableSeatsNum(perfTimeId, seatIds);
     }
 
-    public void setReservedSeatsCancel(List<Integer> reservationIds) {
-        seatMapper.setReservedSeatsCancel(reservationIds);
+    public void setSeatsCancel(List<Integer> reservationIds) {
+        seatMapper.setSeatsCancel(reservationIds);
     }
 }

--- a/src/main/java/com/show/showticketingservice/service/SeatService.java
+++ b/src/main/java/com/show/showticketingservice/service/SeatService.java
@@ -30,4 +30,7 @@ public class SeatService {
         return seatMapper.getReservableSeatsNum(perfTimeId, seatIds);
     }
 
+    public void setReservedSeatsCancel(List<Integer> reservationIds) {
+        seatMapper.setReservedSeatsCancel(reservationIds);
+    }
 }

--- a/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
@@ -1,5 +1,6 @@
 package com.show.showticketingservice.tool.advice;
 
+import com.show.showticketingservice.exception.reservation.ReservationIdNotExistsException;
 import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
 import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
@@ -24,6 +25,13 @@ public class ReservationExceptionAdvice {
     @ExceptionHandler(SeatsNotReservableException.class)
     public ResponseEntity<ExceptionResponse> seatsNotReservableException(final SeatsNotReservableException e, WebRequest request) {
         log.error("reservation failed - request reservation with invalid seats", e);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ReservationIdNotExistsException.class)
+    public ResponseEntity<ExceptionResponse> reservationIdNotExistsException(final ReservationIdNotExistsException e, WebRequest request) {
+        log.error("reservation cancel fail", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
+++ b/src/main/java/com/show/showticketingservice/tool/advice/ReservationExceptionAdvice.java
@@ -1,6 +1,6 @@
 package com.show.showticketingservice.tool.advice;
 
-import com.show.showticketingservice.exception.reservation.ReservationIdNotExistsException;
+import com.show.showticketingservice.exception.reservation.ReservationNumNotExistsException;
 import com.show.showticketingservice.exception.reservation.ReserveAllowedQuantityExceededException;
 import com.show.showticketingservice.exception.reservation.SeatsNotReservableException;
 import com.show.showticketingservice.model.responses.ExceptionResponse;
@@ -29,8 +29,8 @@ public class ReservationExceptionAdvice {
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(ReservationIdNotExistsException.class)
-    public ResponseEntity<ExceptionResponse> reservationIdNotExistsException(final ReservationIdNotExistsException e, WebRequest request) {
+    @ExceptionHandler(ReservationNumNotExistsException.class)
+    public ResponseEntity<ExceptionResponse> reservationNumNotExistsException(final ReservationNumNotExistsException e, WebRequest request) {
         log.error("reservation cancel fail", e);
         ExceptionResponse exceptionResponse = new ExceptionResponse(e.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);

--- a/src/main/resources/mybatis/mappers/ReservationMapper.xml
+++ b/src/main/resources/mybatis/mappers/ReservationMapper.xml
@@ -11,7 +11,7 @@
         </foreach>
     </insert>
 
-    <delete id="cancelReservedSeats" parameterType="java.util.List">
+    <delete id="cancelSeats" parameterType="map">
         DELETE FROM reservation
         WHERE id IN
         <foreach collection="reservationIds" item="reservationId" open="(" close=")" separator=",">
@@ -19,11 +19,17 @@
         </foreach>
     </delete>
 
-    <select id="getReservedSeatsNum" parameterType="java.util.List" resultType="int">
-        SELECT COUNT(id) FROM reservation WHERE id IN
-        <foreach collection="reservationIds" item="reservationId" open="(" close=")" separator=",">
+    <select id="getSeatNumToCancel" parameterType="map" resultType="int">
+        SELECT COUNT(r.id) FROM reservation r
+        INNER JOIN seat st ON st.id = r.seatId
+        INNER JOIN performanceTime pt ON st.perfTimeId = pt.id
+        WHERE r.id IN
+        <foreach collection="reservationInfo.reservationIds" item="reservationId" open="(" close=")" separator=",">
             #{reservationId}
         </foreach>
+        AND pt.id = #{reservationInfo.perfTimeId}
+        AND pt.performanceId = #{reservationInfo.performanceId}
+        AND r.userId = #{userId}
     </select>
 
 </mapper>

--- a/src/main/resources/mybatis/mappers/ReservationMapper.xml
+++ b/src/main/resources/mybatis/mappers/ReservationMapper.xml
@@ -11,4 +11,19 @@
         </foreach>
     </insert>
 
+    <delete id="cancelReservedSeats" parameterType="java.util.List">
+        DELETE FROM reservation
+        WHERE id IN
+        <foreach collection="reservationIds" item="reservationId" open="(" close=")" separator=",">
+            #{reservationId}
+        </foreach>
+    </delete>
+
+    <select id="getReservedSeatsNum" parameterType="java.util.List" resultType="int">
+        SELECT COUNT(id) FROM reservation WHERE id IN
+        <foreach collection="reservationIds" item="reservationId" open="(" close=")" separator=",">
+            #{reservationId}
+        </foreach>
+    </select>
+
 </mapper>

--- a/src/main/resources/mybatis/mappers/SeatMapper.xml
+++ b/src/main/resources/mybatis/mappers/SeatMapper.xml
@@ -46,7 +46,7 @@
         AND reserved = FALSE
     </select>
 
-    <update id="setReservedSeatsCancel" parameterType="java.util.List">
+    <update id="setSeatsCancel" parameterType="java.util.List">
         UPDATE seat
         SET reserved = FALSE
         WHERE id IN

--- a/src/main/resources/mybatis/mappers/SeatMapper.xml
+++ b/src/main/resources/mybatis/mappers/SeatMapper.xml
@@ -46,4 +46,18 @@
         AND reserved = FALSE
     </select>
 
+    <update id="setReservedSeatsCancel" parameterType="java.util.List">
+        UPDATE seat
+        SET reserved = FALSE
+        WHERE id IN
+        (
+            SELECT seatId
+            FROM reservation
+            WHERE id IN
+            <foreach collection="reservationIds" item="reservationId" open="(" close=")" separator=", ">
+                #{reservationId}
+            </foreach>
+        )
+    </update>
+
 </mapper>


### PR DESCRIPTION
### 기능
- 예매한 좌석을 삭제하는 기능
- reservation 테이블에서 reservation id를 통해 예매 삭제
- seat 테이블에서 reservation id를 통해 reserved 값을 false로 예매 가능하도록 변경
- 예매 가능 좌석과 관련된 cache 기능을 키값인 공연 id, 공연 시간 id를 통해 evict 처리
- 공연 시간id, 공연장 id, 유저 id와 관련된 reservation Id인지 체크
- 트랜잭션 처리
- 단위 테스트 작성

### 기능 목록

- [x] 공연 예매 취소 기능 구현
- [x] 좌석과 관련된 cache 기능 evict 처리
- [x] 트랜잭션 처리
- [x] 단위 테스트 작성